### PR TITLE
Release v1.3

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,7 +11,7 @@ assignees: UnconnectedBedna
 A clear and concise description of what the bug is.
 
 **To Reproduce**  
-Steps to reproduce the behavior:
+Steps to reproduce the behavior.
 
 **Expected behavior**  
 A clear and concise description of what you expected to happen.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,19 +7,20 @@ assignees: UnconnectedBedna
 
 ---
 
-**Describe the bug**
+**Describe the bug**  
 A clear and concise description of what the bug is.
 
-**To Reproduce**
+**To Reproduce**  
 Steps to reproduce the behavior:
 
-**Expected behavior**
+**Expected behavior**  
 A clear and concise description of what you expected to happen.
 
-**Harware (please complete the following information):**
+**Harware (please complete the following information):**  
  - Hardware: [f.ex. raspberrypi 4 OR orangepi 5]
  - OS: [f.ex. rpi bookworm OR armbian for opi5]
 
-**Additional context**
-Add any other context about the problem here.
-Run in debug mode by using `-l` option and please provide the output of shrink-backup.log
+**Additional context**  
+Add any other context about the problem here.  
+Run in debug mode by using `-l` option and please provide the output of `shrink-backup.log`  
+Copy/paste the **complete log of the backup that fails** (not the entire log file, there could be multiple backups), not just the parts you think could be useful.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2024, Marcus Johansson
+Copyright (c) 2024-present, Marcus Johansson
 https://github.com/UnconnectedBedna
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Having a "broken pipe" error during backup has in my experience never broken an 
 
 #### `--loop` (Loop img file)
 Use `--loop` to loop an img file to your `/dev`.  
-This functionality works on any linux system, just use the script on any img file anywhere available to the computer.
+This functionality works on any linux system, just use the script on any img type file (not limited to `.img` extension files) anywhere available to the computer.
 
 **Example:** `sudo shrink-backup --loop /path/to/backup.img`
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Usage: sudo shrink-backup [-Uatyelhz] [--fix] [--loop] [--f2fs] imagefile.img [e
   -l            Write debug messages to logfile shrink-backup.log located in same directory as script
   -z            Make script zoom at light-speed, only question prompts might slow it down
                   Can be combined with -y for UNSAFE ultra-mega-superduper-speed
+  -q --quiet    Do not print rsync copy process
+  --no-color    Run script without color formatted text
   --fix         Try to fix the img file if -a fails with a "broken pipe" error
   --loop [img]  Loop img file and exit, works in combination with -l & -z
                   If optional [extra space] is defined, the img file will be extended with the amount before looping

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Backing up/restoring, to/from: usb-stick `/dev/sdX` with Raspberry pi os has bee
 
 **Ultra-fast incremental backups to existing img files.**
 
-See [wiki](https://github.com/UnconnectedBedna/shrink-backup/wiki) for information about installation methods, usage and examples.  
+See [wiki](https://github.com/UnconnectedBedna/shrink-backup/wiki) for information about [installation methods](https://github.com/UnconnectedBedna/shrink-backup/wiki/Installing), usage and examples.  
 [Ideas and feedback](https://github.com/UnconnectedBedna/shrink-backup/discussions) is always appreciated, whether it's positive or negative. Please just keep it civil. :)  
 If you find a bug or think something is missing in the script, please file a [Bug report or Feature request](https://github.com/UnconnectedBedna/shrink-backup/issues/new/choose)
 
@@ -42,32 +42,37 @@ Script for creating an .img file and subsequently keeing it updated (-U), autoex
 Directory where .img file is created is automatically excluded in backup
 ########################################################################
 Usage: sudo shrink-backup [-Uatyelhz] [--fix] [--loop] [--f2fs] imagefile.img [extra space (MiB)]
-  -U            Update existing img file (rsync to existing img)
-                  Optional [extra space] extends img root partition
-  -a            Autocalculate root size partition, [extra space] is ignored
-                  When used in combination with -U:
-                  Expand if partition is >=256MiB smaller than autocalculated recommended minimum
-                  Shrink if partition is >=512MiB bigger than autocalculated recommended minimum
-  -t            Use exclude.txt in same folder as script to set excluded directories
-                  One directory per line: "/dir" or "/dir/*" to only exclude contents
-  -y            Disable prompts in script (please use this option with care!)
-  -e            Disable autoexpansion on root filesystem when image is booted
-  -l            Write debug messages to logfile shrink-backup.log located in same directory as script
-  -z            Make script zoom at light-speed, only question prompts might slow it down
-                  Can be combined with -y for UNSAFE ultra-mega-superduper-speed
-  -q --quiet    Do not print rsync copy process
-  --no-color    Run script without color formatted text
-  --fix         Try to fix the img file if -a fails with a "broken pipe" error
-  --loop [img]  Loop img file and exit, works in combination with -l & -z
-                  If optional [extra space] is defined, the img file will be extended with the amount before looping
-                  NOTE that only the file gets truncated, no partitions
-                  Useful if you for example want to manually manage the partitions
-  --f2fs        Convert root filesystem on img from ext4 to f2fs
-                  Only works on new img file, not in combination with -U
-                  Will make backups of fstab & cmdline.txt to: fstab.shrink-backup.bak & cmdline.txt.shrink-backup.bak
-                  Then change ext4 to f2fs in both files and add discard to options on root partition in fstab
-  --version     Print version and exit
-  -h --help     Show this help snippet
+  -U              Update existing img file (rsync to existing img)
+                    Optional [extra space] extends img root partition
+  -a              Autocalculate root size partition, [extra space] is ignored
+                    When used in combination with -U:
+                    Expand if partition is >=256MiB smaller than autocalculated recommended minimum
+                    Shrink if partition is >=512MiB bigger than autocalculated recommended minimum
+  -t              Use exclude.txt in same folder as script to set excluded directories
+                    One directory per line: "/dir" or "/dir/*" to only exclude contents
+  -y              Disable prompts in script (please use this option with care!)
+  -e              Disable autoexpansion on root filesystem when image is booted
+  -l              Write debug messages to logfile shrink-backup.log located in same directory as script
+  -z              Make script zoom at light-speed, only question prompts might slow it down
+                    Can be combined with -y for UNSAFE ultra-mega-superduper-speed
+  -q --quiet      Do not print rsync copy process
+  --no-color      Run script without color formatted text
+  --fix           Try to fix the img file if -a fails with a "broken pipe" error
+  --loop [img]    Loop img file and exit, works in combination with -l & -z
+                    If optional [extra space] is defined, the img file will be extended with the amount before looping
+                    NOTE that only the file gets truncated, no partitions
+                    Useful if you for example want to manually manage the partitions
+  --chroot [img]  Use systemd-nspawn. Loop img file, mount to temp directory, enter chroot environment and drop to shell
+                    This will let you make changes in a chroot environment directly on the img file
+                    For example update with package manager or rebuild initramfs
+                    The script will keep running in the background
+                    Type 'exit' when done. Script will unmount, remove temp directory/loop and exit
+  --f2fs          Convert root filesystem on img from ext4 to f2fs
+                    Only works on new img file, not in combination with -U
+                    Will make backups of fstab & cmdline.txt to: fstab.shrink-backup.bak & cmdline.txt.shrink-backup.bak
+                    Then change ext4 to f2fs in both files and add discard to options on root partition in fstab
+  --version       Print version and exit
+  -h --help       Show this help snippet
 ########################################################################
 Examples:
 sudo shrink-backup -a /path/to/backup.img (create img, resize2fs calcualtes size)

--- a/README.md
+++ b/README.md
@@ -157,8 +157,8 @@ To remind yourself: `lsblk /dev/loop*` (if you forgot what `loop` it got assigne
 #### `--f2fs` (Convert `ext4` into `f2fs` on img file)
 > [!IMPORTANT]
 > ONLY use this for **CONVERTING** filesystem into img file, **if you already have `f2fs` on the system you backup from, do not use this option.**
+> The script will detect what filesystem is used on `root` and act accordingly.  
 
-The script will detect what filesystem is used on `root` and act accordingly.  
 Only supported with new backups, not when using `-U`.
 
 Autoexpansion at boot is not supported for `f2fs` (there is no way of resizing a mounted `f2fs` filesystem, unlike with `ext4`) so resizing root partition have to be made manually after writing img to sd-card.  

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ The script will **ONLY** look at your `root` partition when calculating sizes.
 **Not excluding other mounts will copy that data to the img `root` partition, not create more partitions,** so make sure to **_manually add_ `[extra space]`** if you do this.  
 Experimental [`btrfs`](#btrfs) is an exception to this, all subvolumes will be created.
 
-See [[#`--loop` (Loop img file)|--loop]] for how to manually include more partitions in the img.
+See [--loop](#--loop-loop-img-file) for how to manually include more partitions in the img.
 <br>
 <br>
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Feel free to make a [feature request](https://github.com/UnconnectedBedna/shrink
 
 Full functionality for usage inside [webmin](https://webmin.com/) (including "custom command" button). Thank you to [iliajie](https://github.com/iliajie) for helping out. ❤️
 
-**Latest release:** [shrink-backup.v1.2](https://github.com/UnconnectedBedna/shrink-backup/releases/download/v1.2/shrink-backup.v1.2.tar.gz)  
+**Latest release:** [shrink-backup.v1.3](https://github.com/UnconnectedBedna/shrink-backup/releases/download/v1.3/shrink-backup.v1.3.tar.gz)  
 [**Testing branch:**](https://github.com/UnconnectedBedna/shrink-backup/tree/testing) If you want to use the absolute latest version. There might be bugs.
 
 **Very fast restore thanks to minimal size of img file.**

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ shrink-backup is a very fast utility for backing up your SBC:s into minimal boot
 Supports backing up `root` & `boot` (if existing) partitions. Data from other partitions will be written to `root` if not excluded (exception for [`btrfs`](#btrfs), all existing subvolumes in `/etc/fstab` will be created).  
 Please see [`Info`](#info) section.
 
-Autoexpansion tested on **Raspberry Pi** os (bookworm and older), **Armbian**, **Manjaro-arm**, **DietPi** & **ArchLinuxARM** for rpi with `ext4` or [`f2fs`](#f2fs) root partition.  
+Autoexpansion tested on **Raspberry Pi OS** (bookworm and older), **Armbian**, **Manjaro-arm**, **DietPi** & **ArchLinuxARM** for rpi with `ext4` or [`f2fs`](#f2fs) root partition.  
 (Also **experimental** [`btrfs`](#btrfs) functionality, please read further down)  
 Full functionality for usage inside [webmin](https://webmin.com/) (including "custom command" button). Thank you to [iliajie](https://github.com/iliajie) for helping out. ❤️
 
@@ -159,7 +159,7 @@ To remind yourself: `lsblk /dev/loop*` (if you forgot what `loop` it got assigne
 > ONLY use this for **CONVERTING** filesystem into img file, **if you already have `f2fs` on the system you backup from, do not use this option.**
 > The script will detect what filesystem is used on `root` and act accordingly.  
 
-Only supported with new backups, not when using `-U`.
+Only supported for Raspberry Pi OS with new backups, not when using `-U`.
 
 Autoexpansion at boot is not supported for `f2fs` (there is no way of resizing a mounted `f2fs` filesystem, unlike with `ext4`) so resizing root partition have to be made manually after writing img to sd-card.  
 Resize operations (when updating backup with `-U`) is not available for `f2fs` _as of now_.

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Please read information about [`f2fs`](#f2fs) further down.
 <br>
 
 ### Info
-**Rsync WILL cross filesystem boundries, so make sure you [[#`-t` (exclude.txt)|exclude]] external mounts unless you want them included in the backup. (separate `/home` for example)**
+**Rsync WILL cross filesystem boundries, so make sure you [exclude](#-t-excludetxt) external mounts unless you want them included in the backup. (separate `/home` for example)**
 
 The script will **ONLY** create `boot` (if exits) and `root` partitions on the img file.  
 The script will **ONLY** look at your `root` partition when calculating sizes.  

--- a/README.md
+++ b/README.md
@@ -9,30 +9,29 @@ Please see [`Info`](#info) section.
 
 Autoexpansion tested on **Raspberry Pi** os (bookworm and older), **Armbian**, **Manjaro-arm**, **DietPi** & **ArchLinuxARM** for rpi with `ext4` or [`f2fs`](#f2fs) root partition.  
 (Also **experimental** [`btrfs`](#btrfs) functionality, please read further down)  
-Full support for usage inside [webmin](https://webmin.com/) (including "custom command" button). Thank you to [iliajie](https://github.com/iliajie) for helping out. ❤️
+Full functionality for usage inside [webmin](https://webmin.com/) (including "custom command" button). Thank you to [iliajie](https://github.com/iliajie) for helping out. ❤️
 
 **Latest release:** [shrink-backup.v1.2](https://github.com/UnconnectedBedna/shrink-backup/releases/download/v1.2/shrink-backup.v1.2.tar.gz)  
 [**Testing branch:**](https://github.com/UnconnectedBedna/shrink-backup/tree/testing) If you want to use the absolute latest version. There might be bugs.
 
 **Very fast restore thanks to minimal size of img file.**
 
-**Can back up any device as long as filesystem on root is `ext4`** or **[`f2fs`](#f2fs)** (experimental [`btrfs`](#btrfs))  
+**Can backup any device as long as filesystem on root is `ext4`** or **[`f2fs`](#f2fs)** (experimental [`btrfs`](#btrfs))  
 Default device that will be backed up is determined by scanning what disk-device `root` resides on.  
 This means that **if** `boot` is a partition, that partition must be on the **same device and before the `root` partition**.  
 The script considers everything on the device before `root` as the bootsector.
 
 Backing up/restoring, to/from: usb-stick `/dev/sdX` with Raspberry pi os has been tested and works. Ie, writing an sd-card img to a usb-stick and vice versa works.
 
-**Ultra-fast incremental backups to existing img files.** 
+**Ultra-fast incremental backups to existing img files.**
 
 See [wiki](https://github.com/UnconnectedBedna/shrink-backup/wiki) for information about installation methods, usage and examples.  
 [Ideas and feedback](https://github.com/UnconnectedBedna/shrink-backup/discussions) is always appreciated, whether it's positive or negative. Please just keep it civil. :)  
 If you find a bug or think something is missing in the script, please file a [Bug report or Feature request](https://github.com/UnconnectedBedna/shrink-backup/issues/new/choose)
 
-**Don't forget to ensure the script is executable.**
+**To restore a backup, simply "burn" the img file to a device using your favorite method.**
 
-**To restore a backup, simply "burn" the img file to a device using your favorite method.**  
-When booting up a restored image with autoresize active, **please wait until the the reboot sequence has occurred.** The login prompt _may_ very well become visible before the autoresize function has rebooted.
+When booting a restored image with autoresize active, **please wait until the the reboot sequence has occurred.** The login prompt _may_ very well become visible before the autoresize function has rebooted.
 
 <hr>
 
@@ -52,7 +51,7 @@ Usage: sudo shrink-backup [-Uatyelhz] [--fix] [--loop] [--f2fs] imagefile.img [e
   -t            Use exclude.txt in same folder as script to set excluded directories
                   One directory per line: "/dir" or "/dir/*" to only exclude contents
   -y            Disable prompts in script (please use this option with care!)
-  -e            DISABLE autoexpansion on root filesystem when image is booted
+  -e            Disable autoexpansion on root filesystem when image is booted
   -l            Write debug messages to logfile shrink-backup.log located in same directory as script
   -z            Make script zoom at light-speed, only question prompts might slow it down
                   Can be combined with -y for UNSAFE ultra-mega-superduper-speed
@@ -82,11 +81,14 @@ sudo shrink-backup -l --loop /path/to/backup.img 1024 (write to log file, expand
 The folder where the img file is created will **ALWAYS be excluded in the backup.**<br>
 If `-t` option is selected, `exclude.txt` **MUST exist** (but can be empty) within the **directory where the script is located** or the script will exit with an error.
 
+> [!NOTE]
+> If installed using `curl`, location and name of file is different. Please read [install with curl](https://github.com/UnconnectedBedna/shrink-backup/wiki/Installing#curl---shrink-backup-install-script) for more information.
+
 Use one directory per line in `exclude.txt`.  
 `/directory/*` = create directory but exclude content.  
 `/directory` = exclude the directory completely.
 
-If `-t` is **NOT** selected the following folders will be excluded:
+If `-t` is **NOT** selected the following will be excluded:
 ```
 /lost+found
 /proc/*
@@ -102,50 +104,58 @@ If `-t` is **NOT** selected the following folders will be excluded:
 #### `-l` (Log file)
 Use `-l` to write debug info into `shrink-backup.log` file located in the same directory as the script.  
 Please provide this file if filing a [Bug report](https://github.com/UnconnectedBedna/shrink-backup/issues/new/choose)
-<br>
+
+> [!NOTE]
+> If installed using `curl`, location and name of file is different. Please read [install with curl](https://github.com/UnconnectedBedna/shrink-backup/wiki/Installing#curl---shrink-backup-install-script) for more information.
 <br>
 
 #### `-z` (Zoom speed)
-The `-z` "zoom" option simply removes the one second sleep at each prompt to give the user time to read.  
-By using the option, you save 15-25s when running the script.  
-When used in combination with `-y` **warnings will also be bypassed! PLEASE use with care!**
-<br>
+The `-z` "zoom" option simply removes the one second sleep at each info prompt to give the user time to read.  
+By using the option, you save 15-25s when running the script.
+
+> [!CAUTION]
+> When used in combination with `-y` **warnings will also be bypassed! PLEASE use with care!**  
+> The script will for example overwrite files without asking for confirmation!
 <br>
 
 #### `--fix` (Broken pipe)
-Add `--fix` to your options if a backup fails during `rsync` with a "broken pipe" error. You can also _manually add_ `[extra space]` instead of using `-a` to solve this.
+Add `--fix` to your options if a backup fails during `rsync` with a "broken pipe" error. You can also _manually add_ `[extra space]` instead of using `-Ua` to solve this.
 
 **Example:** `sudo shrink-backup -Ua --fix /path/to/backup.img`
 
 The reason it happens is because `rsync` normally deletes files during the backup, not creating a file-list > removing files from img before starting to copy.  
 So if you have removed and added new data on the system you backup from, there is a risk `rsync` tries to copy the new data before deleting data from the img, hence completely filling the img.
 
-Using `--fix` makes `rsync` create a file-list and delete data **before** starting to transfer new data. This also means the backup takes a little longer.  
-Having a "broken pipe" error during backup has in my experience never broken an img backup after either using `--fix` (can be used in combination with `-a`) or adding `[extra space]` while updating the backup with `-U`.
+Using `--fix` configures `rsync` create a file-list and delete data **before** starting to transfer new data. This also means the backup takes a little longer.  
+Having a "broken pipe" error during backup has in my experience never broken an img backup after either using `--fix` or adding `[extra space]` while updating the backup with `-U`.
 <br>
 <br>
 
 #### `--loop` (Loop img file)
-Use `--loop` to loop an img file to your `/dev`.
+Use `--loop` to loop an img file to your `/dev`.  
+This functionality works on any linux system, just use the script on any img file anywhere available to the computer.
 
 **Example:** `sudo shrink-backup --loop /path/to/backup.img`
 
-If used in combination with `[extra space]` the amount in MiB will be added to the **IMG FILE** NOT any partition.  
-With this you can for example run `sudo gparted /dev/loop0` (if you have a graphical interface) to manually manage the img partitions in a graphical interface with `gparted`.  
-If you added `[extra space]` this will then show up as unpartitioned space at the end of the device where you can create partition(s) and manually copy data to by mounting the new loop partition that will become visible in `lsblk`.  
-If you do this, don't forget to create or update the img with `-e` (disable autoexpansion) first. Autoexpansion will not work since the space will be occupied by your manually managed partition.
+If used in combination with `[extra space]` the amount in MiB will be added to the **IMG FILE, NOT any partition.**
 
 **Example:** `sudo shrink-backup --loop /path/to/backup.img 1024`
 
-This functionality works on any linux system, just use the script on any img file anywhere available to the computer.
+With this you can for example run: `sudo gparted /dev/loop0` (use correct `loop` it got assigned to) if you have a graphical interface to manually manage the img partitions in a graphical interface with `gparted`.  
+You can ofc use any partition manager for this.  
+If you added `[extra space]` this will then show up as unpartitioned space at the end of the device where you can create partition(s) and manually copy data to by mounting the new `loop` partition(s) that will become visible in `lsblk`.  
+If you do this, don't forget to create or update the img with `-e` (disable autoexpansion) first. Autoexpansion will not work since the space will be occupied by your manually managed partition(s).  
+You can still update the img file with `-U` as long as the img `root` partition is big enough to hold the data from the device you backup from, but make sure to [exclude](#-t-excludetxt) your manually managed partition(s) or they will be copied to the img `root` partition.
 
-To remove the loop: `sudo losetup -d /dev/loop0`, change `loop0` to the correct `dev` it got looped to.  
-To remind yourself: `lsblk /dev/loop*` if you forgot the location after using `--mount`
+To remove the loop: `sudo losetup -d /dev/loop0`, (use correct `loop` it got assigned to)  
+To remind yourself: `lsblk /dev/loop*` (if you forgot what `loop` it got assigned to)
 <br>
 <br>
 
 #### `--f2fs` (Convert `ext4` into `f2fs` on img file)
-ONLY use this for **CONVERTING** filesystem into img file, **if you already have `f2fs` on your root, do not use this option.**  
+> [!IMPORTANT]
+> ONLY use this for **CONVERTING** filesystem into img file, **if you already have `f2fs` on the system you backup from, do not use this option.**
+
 The script will detect what filesystem is used on `root` and act accordingly.  
 Only supported with new backups, not when using `-U`.
 
@@ -160,14 +170,22 @@ Please read information about [`f2fs`](#f2fs) further down.
 <br>
 
 ### Info
-**Rsync WILL cross filesystem boundries, so make sure you [exclude](#-t-excludetxt) external mounts unless you want them included in the backup. (separate `/home` for example)**
 
-The script will **ONLY** create `boot` (if exits) and `root` partitions on the img file.  
-The script will **ONLY** look at your `root` partition when calculating sizes.  
+The script works on any device as long as root filesystem is `ext4`, [`f2fs`](#f2fs) or **experimental** [`btrfs`](#btrfs).  
+Since the script uses `lsblk` to crosscheck with `/etc/fstab` to figure out where `root` resides it does not matter what device it is located on.
+
+Even if you forget to disable autoexpansion on a non supported OS, the backup will not fail, it will just skip creating the autoresize script.
+
+> [!IMPORTANT]
+> **Rsync WILL cross filesystem boundries, so make sure you [exclude](#-t-excludetxt) external mounts and other partitions unless you want them included in the `root` partition of the img backup.** (separate `/home` for example)
+
+- The script will **ONLY** create `boot` (if exits) and `root` partitions on the img file.
+- The script will **ONLY** look at your `root` partition when calculating sizes.
+
 **Not excluding other mounts will copy that data to the img `root` partition, not create more partitions,** so make sure to **_manually add_ `[extra space]`** if you do this.  
 Experimental [`btrfs`](#btrfs) is an exception to this, all subvolumes will be created.
 
-See [--loop](#--loop-loop-img-file) for how to manually include more partitions in the img.
+See [--loop](#--loop-loop-img-file) for how to manually include more partitions on the img.
 <br>
 <br>
 
@@ -186,15 +204,46 @@ See [--loop](#--loop-loop-img-file) for how to manually include more partitions 
 
 ## Image creation
 
-To create a backup img using recomended size, use the `-a` option and the path to the img file.
+The easiest way to create a backup is to let the script configure the size.  
+To create a backup img using recommended size, use the `-a` option and the path to the img file.
 
 **Example:** `sudo shrink-backup -a /path/to/backup.img`
 
-Theoretically the script should work on any device as long as root filesystem is `ext4`, [`f2fs`](#f2fs) or **experimental** [`btrfs`](#btrfs).  
-Since the script uses `lsblk` to crosscheck with `/etc/fstab` to figure out where `root` resides it does not matter what device it is on.
-
-Even if you forget to disable autoexpansion on a non supported OS, the backup will not fail, it will just skip creating the autoresize scripts. :)
+The script will set the img size by requesting recommended minimum size from `e2fsck` or `du` (`e2fsck` does not work on `f2fs` f.ex).  
+This is not the absolute smallest size you can achieve but is the "safest" way to create a "smallest possible" img file.  
+If the size of the filesystem you are backing up from does not increase too much, you can most likely keep it updated with the [update function](#image-update) (`-U`) of the script.
 <br>
+<br>
+### Manually configure size
+
+To manually configure size use `[extra space]`  
+Space is added on top of `df` reported "used space", not the size of the partition.  
+`[extra space]` is in **MiB**, so if you want to add **1G**, add **1024**.
+
+**Example:** `sudo shrink-backup /path/to/backup.img 1024`
+<br>
+<br>
+### Smallest image possible
+
+To get the absolute smallest img file possible, do **NOT** use `-a` option, instead set `[extra space]` to `0`
+
+**Example:** `sudo shrink-backup /path/to/backup.img 0`
+
+This will instruct the script to get the used space from `df` and add 128MiB "*wiggle room*".  
+If you are like me, doing a lot of testing, rewriting the sd-card multiple times when experimenting, the extra time it takes each "burn" will add up pretty fast.
+
+**Example:**
+```
+-rw-r--r-- 1 root root 3.7G Jul 22 21:27 test.img # file created with -a
+-rw-r--r-- 1 root root 3.3G Jul 22 22:37 test0.img # file created with 0
+```
+
+> [!IMPORTANT]
+> Because of how filesystems work, `df` is never a true representation of what will actually fit in a created img file.  
+> Each file, no matter the size, will take up one block of the filesystem, so if you have a LOT of very small files (running `docker` f.ex) the "0 added space method" might fail during rsync. Increase the 0 a little bit and retry.
+>
+> Using this method also means you have VERY little free space on the img file after creation.  
+> If the filesystem you back up from increases in size, an update (`-U`) of the img file might fail with lack of space.
 <br>
 
 ### Order of operations - Image creation
@@ -212,44 +261,6 @@ Even if you forget to disable autoexpansion on a non supported OS, the backup wi
 12. Tries to create autoresize scripts if supported on OS and not disabled with `-e`.
 13. Unmounts and removes temp directory and file (file created for `rsync` log output).
 
-Added space is added on top of `df` reported "used space", not the size of the partition. Added space is in MiB, so if you want to add 1G, add 1024.
-
-The script can be instructed to set the img size by requesting recomended minimum size from `e2fsck` or `du` (`e2fsck` does not work on `f2fs` f.ex) by using the `-a` option.  
-This is not the absolute smallest size you can achieve but is the "safest" way to create a "smallest possible" img file.  
-If you do not increase the size of the filesystem you are backing up from too much, you can most likely keep it updated with the update function (`-U`) of the script.
-
-By using `-a` in combination with `-U` the script will resize the img file if needed (not supported on [`f2fs`](#f2fs)).  
-Using combination `-Ua` on an img that has become overfilled works, if not add `--fix` and retry.  
-Please see [`--fix`](#--fix-broken-pipe) and [image update](#image-update) sections for more information.
-<br>
-<br>
-
-### Smallest image possible
-
-To get the absolute smallest img file possible, do NOT use `-a` option, instead set `[extra space]` to `0`
-
-**Example:** `sudo shrink-backup /path/to/backup.img 0`
-
-This will instruct the script to get the used space from `df` and adding 128MiB "*wiggle room*".  
-If you are like me, doing a lot of testing, rewriting the sd-card multiple times when experimenting, the extra time it takes each "burn" will add up pretty fast.
-
-**Example:**
-```
--rw-r--r-- 1 root root 3.7G Jul 22 21:27 test.img # file created with -a
--rw-r--r-- 1 root root 3.3G Jul 22 22:37 test0.img # file created with 0
-```
-
-**Disclaimer!**  
-Because of how filesystems work, `df` is never a true representation of what will actually fit in a created img file.  
-Each file, no matter the size, will take up one block of the filesystem, so if you have a LOT of very small files (running `docker` f.ex) the "0 added space method" might fail during rsync. Increase the 0 a little bit and retry.
-
-This also means you have VERY little free space on the img file after creation.  
-If the filesystem you back up from increases in size, an update (`-U`) of the img file might fail.
-
-By using `-a` in combination with `-U` the script will resize the img file if needed (not supported on [`f2fs`](#f2fs)).  
-Using combination `-Ua` on an img that has become overfilled works, if not add `--fix` and retry.  
-Please see [`--fix`](#--fix-broken-pipe) and [Image update](#image-update) sections for more information.
-
 <hr>
 
 ## Image update
@@ -259,57 +270,90 @@ To update an existing img file simply use the `-U` option and the path to the im
 **Example:** `sudo shrink-backup -U /path/to/backup.img`
 <br>
 <br>
+### Autoresizing img when updating
 
+If `-a` is used in combination with `-U`, the script will compare the `root` partition on the img file to the size `resize2fs` recommends as minimum (or `du` calculations depending on filesystem).  
+
+**Example:** `sudo shrink-backup -Ua /path/to/backup.img`
+
+> [!NOTE]
+> - The **img file** `root` **partition** needs to be **>=256MB smaller** than `resize2fs` recommended minimum (or `du` calculations) to be **expanded**.
+> - The **img file** `root` **partition** needs to be **>=512MB bigger** than `resize2fs` recommended minimum (or `du` calculations) to be **shrunk**.
+>
+> This is to protect from unnecessary resizing operations most likely not needed.
+
+Using combination `-Ua` on an img that has become overfilled works, if not use [`--fix`](#--fix-broken-pipe) or manually add `[extra space]` and retry.
+<br>
+<br>
+### Manually resizing img when updating
+
+Only expansion is possible with this method.  
+If `[extra space]` is used in combination with `-U`, the `root` partition of the img file will be expanded by that amount.  
+`[extra space]` is in **MiB**, so if you want to add **1G**, add **1024**.
+
+**Example:** `sudo shrink-backup /path/to/backup.img 1024`
+
+**No checks are being performed to make sure the data you want to back up will actually fit.**  
+
+Resizing operations are not supported with  [`f2fs`](#f2fs).
+<br>
+<br>
 ### Order of operations - Image update
 1. Loops the img file.
 2. Probes the loop of the img file for information about partitions.
-3. If `-a` is selected, calculates sizes by comparing `root` sizes on system and img file by using `fdisk` & `resize2fs` (or `du` depending on filesystem).
-4. Expands filesystem on img file if requested and needed or if _manually added_ `[extra space]` is used.
+3. If `-a` is selected, calculates sizes by comparing `root` used space on system and img file by using `fdisk` & `resize2fs` (or `du` depending on filesystem).
+4. Expands filesystem on img file if requested (`-a`) and conditions were met in point 3, or if _manually added_ `[extra space]` is used.
 5. Creates temp directory and mounts `root` partition from loop.
-6. Checks if `boot` partition exists, if true, checks `fstab` and creates directory on `root` and mounts accordingly from loop.
+6. Checks if `boot` partition exists, if true, checks `fstab` and mounts accordingly from loop.
 7. Uses `rsync` to sync filesystems.
-8. Shrinks filesystem on img file if `-a` was used and conditions were met in point 3.
+8. Shrinks filesystem on img file if requested (`-a`) and conditions were met in point 3.
 9. Tries to create autoresize scripts if supported on OS and not disabled with `-e`.
 10. Unmounts and removes temp directory and file (file created for `rsync` log output).
-<br>
-
-### Resizing img file when updating
-If `-a` is used in combination with `-U`, the script will compare the root partition on the img file to the size `resize2fs` recommends as minimum (or `du` calculations depending on filesystem).
-
-The **img file** `root` **partition** needs to be **>=256MB smaller** than `resize2fs` (or `du` calculations) recommended minimum to be expanded.  
-The **img file** `root` **partition** needs to be **>=512MB bigger** than `resize2fs` (or `du` calculations) recommended minimum to be shrunk.  
-This is to protect from unessesary resizing operations most likely not needed.
-
-If _manually added_ `[extra space]` is used in combination with `-U`, the img file's `root` partition will be expanded by that amount. **No checks are being performed to make sure the data you want to back up will actually fit.**  
-Only expansion is possible with this method.
 
 <hr>
 
 ## f2fs
-The script will detect `f2fs` on `root` automatically and act accordingly.  
-**Do NOT USE [`--f2fs`](#--f2fs-Convert-ext4-into-f2fs-on-img-file) unless you are converting from a `ext4` filesystem (on your system) into `f2fs` on the img file.**
+The script will detect `f2fs` on `root` automatically and act accordingly.
 
-Autoexpansion at boot is not possible with `f2fs`. User will have to manually expand img to cover entire storage media (f.ex sd-card) when restoring.  
-Resizing of img `root` partition while updating img (`-U`) is not possible with `f2fs` _as of now_. User will have to create a new backup if img runs out of space.  
-This is something I am planning to implement further down the line.
+> [!NOTE]
+> **Do NOT USE [`--f2fs`](#--f2fs-Convert-ext4-into-f2fs-on-img-file) unless you are converting from a `ext4` filesystem (on your system) into `f2fs` on the img file.**
+
+Autoexpansion at boot is not possible with `f2fs`. User will have to manually expand img to cover entire storage media (f.ex sd-card) before booting a restored img.  
+Resizing img `root` partition while updating (`-U`) is not possible with `f2fs` _as of now_. User will have to create a new backup if img runs out of space.  
+This is something planned to be implemented further down the line.
 
 <hr>
 
 ## btrfs
 
-**ALL testing has been done on Manjaro-arm**  
-**THIS IS NOT A CLONE, IT IS A BACKUP OF REQUIRED FILES FOR A BOOTABLE BTRFS SYSTEM!**
+**ALL testing has been done on Manjaro-arm**
 
-All options in script should work just as on `ext4`. The script will detect `btrfs` and act accordingly.  
-The script will treat snapshots as nested volumes, so make sure to exclude snapshots if you have any, or directories and **nested volumes** will be created on the img file (not as copy-on-write snapshots).  
-This can be done in `exclude.txt`, wildcards (*) _should_ work.  
-When starting the script, the initial report window will tell you what volumes will be created. **Make sure these are correct before pressing Y**
+> [!NOTE]
+> **THIS IS NOT A CLONE, IT IS A BACKUP OF REQUIRED FILES FOR A BOOTABLE BTRFS SYSTEM!**  
+> Deduplication will not follow from the system you backup from to the img.  
+> The script does NOT utilize `btrfs send|recieve`
 
-As of now, top level subvolumes are checked for in `/etc/fstab` and mounted accordingly, mount options should be preserved (if you for example changed compression).  
-Autoresize function works on Manjaro-arm.
+All options in script should work just as on `ext4`. The script will detect `btrfs` and act accordingly.
+
+As of now, top level subvolumes are checked for in `/etc/fstab` and are created (on img creation) and mounted accordingly, mount options should be preserved (if you for example changed compression).  
+Updating img and autoresize function has been tested and works on **Manjaro-arm**.
+
+> [!WARNING]
+> The script will treat snapshots as nested volumes, so make sure to exclude snapshots if you have any, or directories and **nested volumes** will be created on the img file (not as copy-on-write snapshots).  
+> This can be done in `exclude.txt`, wildcards (`*`) works. 
+> When creating an img, the initial report window will tell you what volumes will be created. **Make sure these are correct before pressing Y.**
+
+<details>
+<summary><i>Fun fact about shrink-backup & btrfs</i></summary>
+I used the script to create a backup of my Arch linux (BTW) desktop installation using `btrfs` with grub as bootloader (separate `/home` subvolume included in the image)<br>
+Wrote that image to a usb stick, and it booted and autoexpanded without problems.<br>
+<br>
+<b>I do NOT recommend using shrink-backup as your main backup software for a desktop computer!</b>
+<b>Use proper backup software for that.</b>
+</details>
 
 <hr>
 
-**Thank you for using my software <3**
+**Thank you for using shrink-backup** ❤️❤️
 
 *"A backup is not really a backup until it has been restored"*

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ If `-t` is **NOT** selected the following will be excluded:
 /mnt/*
 /media/*
 /var/swap
+/snap/*
 ```
 
 #### `-l` (Log file)

--- a/exclude.txt
+++ b/exclude.txt
@@ -7,3 +7,4 @@
 /mnt/*
 /media/*
 /var/swap
+/snap/*

--- a/shrink-backup
+++ b/shrink-backup
@@ -19,7 +19,7 @@ function debug() {
   local log_message="$2"
   if [ "$DEBUG" = true ]; then
     if [ "$log_level" = 'BREAK' ]; then
-      echo '------------------------------------------------------------------------------' >> "$LOG_FILE"
+      echo '-------------------------------------------------------------------------------------' >> "$LOG_FILE"
     else
       if [ $log_level = 'INFO' ]; then
         echo -e "$(date +"%Y-%m-%d %H:%M:%S") [$log_level]  - $log_message" >> "$LOG_FILE"
@@ -129,7 +129,7 @@ function cleanup() {
     debug 'INFO' "Elapsed time: $(date -d@$SECONDS -u +%M.%S)"
     debug 'DEBUG' 'Exiting script'
     if [ "$DEBUG" = true ]; then
-      echo '##############################################################################' >> "$LOG_FILE"
+      echo '#####################################################################################' >> "$LOG_FILE"
     fi
   fi
 }
@@ -172,8 +172,6 @@ F2FS=false
 #STARTLINE="$0 $*" # will produce double // if script is in $PATH
 STARTLINE="$(dirname $0)/$(basename $0) $*" # will produce absolute path if script is in $PATH
 #STARTLINE="$(realpath $0) $*" # same as bove, but will ALWYAS produce absolute path
-COLS=85
-BREAK="$(printf "%${COLS}s" | tr " " "#")"
 
 # If no TTY is available (for example running custom command in webmin)
 if [ -t 0 ]; then
@@ -188,8 +186,10 @@ if [ -t 0 ]; then
   Yellow='\033[0;93m' # high intensity yellow
   Purple='\033[0;95m' # high intensity purple
   NC='\033[0m' # Text Reset - No colors
+  COLORS=true
 else
   TTY_AVAILABILITY='/dev/null'
+  COLORS=false
 fi
 
 
@@ -219,7 +219,7 @@ help() {
   read -r -d '' help << EOM
 ${IWhite}Script for creating an .img file and subsequently keeing it updated (-U), autoexpansion is enabled by default
 Directory where .img file is created is automatically excluded in backup
-$BREAK
+######################################################################################################################
 Usage: ${Green}sudo $(basename "$0") [-Uatyelzh] [--fix] [--loop] [--f2fs] imagefile.img [extra space (MiB)]
   -U            ${IWhite}Update existing img file (rsync to existing img)
                   Optional [extra space] extends img root partition
@@ -247,7 +247,7 @@ Usage: ${Green}sudo $(basename "$0") [-Uatyelzh] [--fix] [--loop] [--f2fs] image
                   Then change ext4 to f2fs in both files and add discard to options on root partition in fstab
   ${Green}--version     ${IWhite}Print version and exit
   ${Green}-h --help     ${IWhite}Show this help snippet
-$BREAK
+######################################################################################################################
 Examples:
 ${Green}sudo $(basename "$0") -a /path/to/backup.img ${White}(create img, automatically set size)
 ${Green}sudo $(basename "$0") -e -y /path/to/backup.img 1024 ${White}(create img, ignore prompts, do NOT autoexpand, add 1024MiB extra space)
@@ -284,7 +284,7 @@ while true; do
     -q|--quiet) RSYNC_TTY=false; shift;;
     --fix) RSYNC_DELETE='--delete-before'; shift;;
     --f2fs) F2FS=true; shift;;
-    --no-color) unset White IWhite Red Blue Green Yellow Purple NC; debug 'DEBUG' '--no-color selected by user, unsetting color variables'; shift;;
+    --no-color) unset White IWhite Red Blue Green Yellow Purple NC; COLORS=false; debug 'DEBUG' '--no-color selected by user, unsetting color variables'; shift;;
     --loop) LOOPRUN=true; IMG_FILE="$2"; shift 2;;
     --) break;;
     *) shift;;
@@ -306,6 +306,16 @@ do
   fi
 done
 
+# Set width
+COLS=85
+if [ $(echo "$IMG_FILE" | wc -m) -gt $(( COLS - 19 )) ]; then
+  COLS=$(( $(echo "$IMG_FILE" | wc -m) + 20 ))
+fi
+if [ $(tput cols) -lt "$COLS" ]; then
+  COLS=$(tput cols)
+fi
+BREAK="$(printf %${COLS}s | tr ' ' '#')"
+
 # Verify script is running as root
 if [ "$EUID" -ne 0 ]; then
   echo -e "${Red}!! THIS SCRIPT MUST BE RUNNING AS ROOT! (WITH SUDO)"
@@ -318,21 +328,26 @@ fi
 function looprun() {
   if [ "$ADDED_SPACE" -ne 0 ]; then
     echo -e "${Yellow}!! ${Red}WARNING! ${Yellow}You have requested to add ${Green}${ADDED_SPACE}MiB ${Yellow}to the img file (NOT partition)"
-    read -p "Do you want to continue with the truncate operation? [y/n] " -n 1 -r
     debug 'INFO' 'Do you want to continue with the truncate operation? [y/n]'
-    if ! [[ "$REPLY" =~ ^[Yy]$ ]]; then
-      echo ''
-      echo -e "${Red}!! Aborting..."
-      exit 4
-    fi
-    echo ''
+    while true; do
+      if [ "$COLORS" = true ]; then
+        read -r -p $'\e[0;37m## \e[0;97mDo you want to continue with the truncate operation? \e[0;92m[y/n] \e[0m' input
+      else
+        read -r -p '## Do you want to continue with the truncate operation? [y/n] ' input
+      fi
+      case $input in
+        [Yy]) break;;
+        [Nn]) echo -e "${Red}!! Aborting..."; exit 4;;
+        *) echo -e "${Yellow}!! ${Red}ERROR! ${Yellow}Please enter ${Green}'y' ${Yellow}or ${Green}'n'${Yellow}"; debug 'WARNING' "ERROR, please enter 'y' or 'n'";;
+      esac
+    done
     debug 'INFO' 'Y or y pressed to confirm'
     echo -e "${White}## ${IWhite}Truncating file by adding ${Green}${ADDED_SPACE}MiB"
     $SLEEPING
     if ! output=$(truncate -s +$(( ADDED_SPACE * 1024 * 1024 )) "$IMG_FILE" 2>&1); then
       echo -e "${Yellow}$output\n${Red}!! TRUNCATE FAILED!!!"
       debug 'BREAK'
-      debug 'ERROR' "TRUNCATE FAILED:\n$output\n------------------------------------------------------------------------------"
+      debug 'ERROR' "TRUNCATE FAILED:\n$output\n-------------------------------------------------------------------------------------"
       exit 1
     fi
   fi
@@ -341,19 +356,18 @@ function looprun() {
   do_loop
 
   echo -e "${White}## ${Green}$IMG_FILE ${IWhite}is looped to ${Green}$LOOP"
-  echo -e "${Purple}##############################################################################"
-  looprun_output="$(lsblk $LOOP)"
-  readarray -t looprun_output < <(echo "$looprun_output")
+  echo -e "${Purple}$BREAK"
+  readarray -t looprun_output < <(lsblk $LOOP)
   for i in "${looprun_output[@]}"; do
+    #echo -e "${Purple}# ${Green}${i} ${Purple}$(printf "%+$(( COLS - 3 - $(echo ${i} | wc -m ) ))s" '#')"
     echo -e "${Purple}# ${Green}${i}"
   done
-  echo -e "${Purple}##############################################################################"
+  echo -e "${Purple}$BREAK"
   echo -e "${White}## ${Green}Done."
-  echo -e "${White}## ${IWhite}To remove loop type: ${Green}sudo losetup -d ${LOOP}"
-
+  echo -e "${White}## ${IWhite}To remove loop, type: ${Green}sudo losetup -d ${LOOP}"
   debug 'DEBUG' 'Exiting script, exit 2'
   if [ "$DEBUG" = true ]; then
-    echo '##############################################################################' >> "$LOG_FILE"
+    echo '#####################################################################################' >> "$LOG_FILE"
   fi
 exit 2
 }
@@ -361,12 +375,12 @@ exit 2
 
 
 # Gather device information
-function get_dev_variables() {
+function dev_variables() {
 
-  # Run get_btrfs_variables and then exit THIS function (added space = 0)
-  if [ "$FSTYPE" == 'btrfs' ] && [ "$AUTORESIZE_RUN" = false ] && [ "$ADDED_SPACE" -eq 0 ]; then
-    debug 'INFO' 'Running function: get_btrfs_variables'
-    get_btrfs_variables
+  # Run btrfs_variabless and then exit THIS function
+  if [ "$FSTYPE" == 'btrfs' ] && [ "$AUTORESIZE_RUN" = false ] && [ "$ADDED_SPACE" -eq 0 ] && [ "$UPDATE" = true ]; then
+    debug 'INFO' 'Running function: btrfs_variabless'
+    btrfs_variabless
     return 0
   fi
 
@@ -375,10 +389,10 @@ function get_dev_variables() {
   # Check if separate boot and root partition exists and set variables accordingly
   if grep -q 'boot' /etc/fstab; then
     debug 'INFO' 'Separate boot partition detected'
-    #LOCAL_DEV_BOOT_PATH=$(lsblk -lpo mountpoint,path | grep 'boot' | awk '{print $2}')
+    BOOT_PARTITION=true
     LOCAL_DEV_BOOT_PATH=$(mount --fake | grep 'boot' | awk '{print $1}')
     LOCAL_DEV_ROOT_PATH=$(mount --fake | grep ' / ' | awk '{print $1}')
-    debug 'DEBUG' "LOCAL_DEV_BOOT_PATH=$LOCAL_DEV_BOOT_PATH | LOCAL_DEV_ROOT_PATH=$LOCAL_DEV_ROOT_PATH"
+    debug 'DEBUG' "BOOT_PARTITION=$BOOT_PARTITION | LOCAL_DEV_BOOT_PATH=$LOCAL_DEV_BOOT_PATH | LOCAL_DEV_ROOT_PATH=$LOCAL_DEV_ROOT_PATH"
     LOCAL_BOOT_UUID=$(lsblk -no uuid "$LOCAL_DEV_BOOT_PATH")
     LOCAL_ROOT_UUID=$(lsblk -no uuid "$LOCAL_DEV_ROOT_PATH")
     LOCAL_ROOT_PARTUUID=$(lsblk -no partuuid "$LOCAL_DEV_ROOT_PATH")
@@ -387,8 +401,9 @@ function get_dev_variables() {
     debug 'DEBUG' "BOOT_PATH=$BOOT_PATH"
   else
     debug 'INFO' 'No boot partition detected'
+    BOOT_PARTITION=false
     LOCAL_DEV_ROOT_PATH=$(mount --fake | grep ' / ' | awk '{print $1}')
-    debug 'DEBUG' "LOCAL_DEV_ROOT_PATH=$LOCAL_DEV_ROOT_PATH"
+    debug 'DEBUG' "BOOT_PARTITION=$BOOT_PARTITION | LOCAL_DEV_ROOT_PATH=$LOCAL_DEV_ROOT_PATH"
     LOCAL_ROOT_UUID=$(lsblk -no uuid "$LOCAL_DEV_ROOT_PATH")
     LOCAL_ROOT_PARTUUID=$(lsblk -no partuuid "$LOCAL_DEV_ROOT_PATH")
     debug 'DEBUG' "LOCAL_ROOT_UUID=$LOCAL_ROOT_UUID | LOCAL_ROOT_PARTUUID=$LOCAL_ROOT_PARTUUID"
@@ -397,21 +412,19 @@ function get_dev_variables() {
   debug 'DEBUG' "LOCAL_ROOT_PARTN=$LOCAL_ROOT_PARTN"
 
   # Collect information about partition sizes
-  #if [ "$UPDATE" = false ] || [ "$ADDED_SPACE" -ne 0 ] || [ "$AUTORESIZE_RUN" = true ]; then
-    debug 'INFO' 'Calculating size for dd to cover bootsector and adding 5MiB (5242880 bytes) to overlap into root (only used in img creation)'
-    #LOCAL_BOOTSECTOR=$(lsblk --bytes -no size "$LOCAL_DEV_BOOT_PATH") # bytes, can not be used, will be 0 if no boot partition exists
-    LOCAL_ROOT_START=$(fdisk -lo device,start "$LOCAL_DEV_PATH" | grep "$LOCAL_DEV_ROOT_PATH" | awk '{print $2}') # 512B blocks
-    LOCAL_BOOTSECTOR=$(( LOCAL_ROOT_START - 1 )) # blocks, to set the actual bootsector, needed in case no boot partition exists
-    LOCAL_ROOT_START=$(( LOCAL_ROOT_START * 512 )) # bytes
-    LOCAL_BOOTSECTOR=$(( LOCAL_BOOTSECTOR * 512 )) # bytes
-    LOCAL_DDBOOTSECTOR=$(( (LOCAL_BOOTSECTOR + 5242880) / 512 )) # 512B blocks, 5242880 = 5MiB in bytes
-    debug 'DEBUG' "LOCAL_ROOT_START=$LOCAL_ROOT_START bytes | LOCAL_BOOTSECTOR=$LOCAL_BOOTSECTOR bytes | LOCAL_DDBOOTSECTOR=$LOCAL_DDBOOTSECTOR 512B blocks"
-  #fi
+  debug 'INFO' 'Calculating size for dd to cover bootsector and adding 5MiB (5242880 bytes) to overlap into root (only used in img creation)'
+  #LOCAL_BOOTSECTOR=$(lsblk --bytes -no size "$LOCAL_DEV_BOOT_PATH") # bytes, can not be used, will be 0 if no boot partition exists
+  LOCAL_ROOT_START=$(fdisk -lo device,start "$LOCAL_DEV_PATH" | grep "$LOCAL_DEV_ROOT_PATH" | awk '{print $2}') # 512B blocks
+  LOCAL_BOOTSECTOR=$(( LOCAL_ROOT_START - 1 )) # blocks, to set the actual bootsector, needed in case no boot partition exists
+  LOCAL_ROOT_START=$(( LOCAL_ROOT_START * 512 )) # bytes
+  LOCAL_BOOTSECTOR=$(( LOCAL_BOOTSECTOR * 512 )) # bytes
+  LOCAL_DDBOOTSECTOR=$(( (LOCAL_BOOTSECTOR + 5242880) / 512 )) # 512B blocks, 5242880 = 5MiB in bytes
+  debug 'DEBUG' "LOCAL_ROOT_START=$LOCAL_ROOT_START bytes | LOCAL_BOOTSECTOR=$LOCAL_BOOTSECTOR bytes | LOCAL_DDBOOTSECTOR=$LOCAL_DDBOOTSECTOR 512B blocks"
 
-  # Set automated calculated size (get_btrfs_variables if btrfs filesystem)
+  # Set automated calculated size (btrfs_variabless if btrfs filesystem)
   if [ "$AUTORESIZE_RUN" = true ] || [ "$UPDATE" = false ] || [ "$FSTYPE" == 'btrfs' ]; then
     debug 'INFO' 'Calculating recommended root size'
-    BLOCKSIZE=$(stat -fc %s /) # bytes, so it works with other localisations
+    BLOCKSIZE=$(stat -fc %s /) # bytes
     debug 'DEBUG' "BLOCKSIZE=${BLOCKSIZE} bytes"
     if [ "$FSTYPE" == 'ext4' ]; then
       debug 'INFO' 'ext4 filesystem detected, using resize2fs to set recommended root size'
@@ -421,25 +434,26 @@ function get_dev_variables() {
     elif [ "$FSTYPE" == 'f2fs' ]; then
       # Method 2, using "used space" straight up
       debug 'INFO' 'f2fs filesystem detected, using df (+512MiB) to set recommended root size'
-      #debug 'INFO' 'f2fs filesystem detected, using du (+512MiB) instead to calculate recommended root size'
-      #LOCAL_AUTORESIZE_MIN=$(du -xsb / | awk '{print $1}') # du version in bytes
       LOCAL_AUTORESIZE_DF=$(df / -k --sync --output=used | tail -1) # 1k blocks
       LOCAL_AUTORESIZE_MIN=$(( LOCAL_AUTORESIZE_DF * 1024 )) # bytes
       LOCAL_AUTORESIZE_MIN=$(( LOCAL_AUTORESIZE_MIN + 536870912 )) # adding 512MiB
       debug 'DEBUG' "LOCAL_AUTORESIZE_MIN=${LOCAL_AUTORESIZE_MIN} bytes"
-    else
-      debug 'INFO' 'Running function: get_btrfs_variables'
-      get_btrfs_variables
+    elif [ "$FSTYPE" == 'btrfs' ]; then
+      debug 'INFO' 'Running function: btrfs_variabless'
+      btrfs_variabless
     fi
   fi
 
   # Method 1, using the value of "size - available"
-  #declare -a LOCAL_DF_OUTPUT=( $(df / -k --sync --output=size,avail | tail -1) ) # 1k blocks, 0 is the first position in an array
-  #LOCAL_USED_SPACE=$(( (${LOCAL_DF_OUTPUT[0]} - ${LOCAL_DF_OUTPUT[1]}) * 1024 )) # bytes, df is in 1k blocks, 0 is the first position
+  #declare -a LOCAL_DF_OUTPUT=( $(df / -k --sync --output=size,avail | tail -1) ) # 1k blocks
+  #LOCAL_USED_SPACE=$(( (${LOCAL_DF_OUTPUT[0]} - ${LOCAL_DF_OUTPUT[1]}) * 1024 )) # bytes, df is in 1k blocks, 0 is the first position in an array
 
   # Method 2, using "used space" straight up
-  declare -a LOCAL_DF_OUTPUT=( $(df / -k --sync --output=used | tail -1) ) # 1k blocks
+  LOCAL_DF_OUTPUT=$(df / -k --sync --output=used | tail -1) # 1k blocks
   LOCAL_USED_SPACE=$(( LOCAL_DF_OUTPUT * 1024 )) # bytes, df is in 1k blocks
+
+  # Method 3, using du
+  #LOCAL_USED_SPACE=$(du -xsb / | awk '{print $1}') # bytes
 
   # Set recommended size if option is selected
   if [ "$AUTORESIZE_RUN" = true ]; then
@@ -469,7 +483,7 @@ return 0
 
 
 # Gather btrfs information
-function get_btrfs_variables() {
+function btrfs_variables() {
 
   BOOT_PATH=$(cat /etc/fstab | grep 'boot' | awk '{print $2}')
   debug 'DEBUG' "BOOT_PATH=$BOOT_PATH"
@@ -482,14 +496,11 @@ function get_btrfs_variables() {
     debug 'DEBUG' "LOCAL_AUTORESIZE_MIN=$LOCAL_AUTORESIZE_MIN bytes"
   fi
   debug 'DEBUG' "Running: btrfs subvolume list / | awk '{print \$9}'"
-  #LOCAL_SUBVOLUMES=( $(sudo btrfs subvolume list / | awk '{print $2,$9}') )
-  declare -ag LOCAL_SUBVOLUMES=( $(btrfs subvolume list / | awk '{print $9}') )
-  #local_subvolumes_count=$(( ${#LOCAL_SUBVOLUMES[@]} / 2 ))
+  declare -ag LOCAL_SUBVOLUMES=( $(btrfs subvolume list / | awk '{print $9}') ) # -g = make variable global
   debug 'DEBUG' "LOCAL_SUBVOLUMES=$(echo ${LOCAL_SUBVOLUMES[@]})"
   if [ "$EXCLUDE_FILE" = true ]; then
-    debug 'INFO' 'Filtering out volumes from exclude.txt'
-    for ((i = 0; i < ${#LOCAL_SUBVOLUMES[@]}; i++)); do
-      #if $(echo "/${LOCAL_SUBVOLUMES[i]}" | grep -q -f "$(dirname $0)/exclude.txt"); then
+    debug 'INFO' 'Filtering out volumes to exclude from exclude.txt or shrink-backup.conf'
+    for ((i = 0; i < ${#LOCAL_SUBVOLUMES[@]}; i++)); do # ${#LOCAL_SUBVOLUMES[@]} gives count
       if $(echo "/${LOCAL_SUBVOLUMES[i]}" | grep -q -f "$EXCLUDE_FILE_LOCATION"); then
         debug 'DEBUG' "Filtering out subvolume: ${LOCAL_SUBVOLUMES[i]}"
         unset LOCAL_SUBVOLUMES["$i"]
@@ -503,106 +514,22 @@ return 0
 
 
 # Gather image information
-function get_img_variables() {
+function img_variables() {
 
-  debug 'DEBUG' "Running: stat -c %s $IMG_FILE"
-  IMG_SIZE=$(stat -c %s "$IMG_FILE")
-  debug 'DEBUG' "IMG_SIZE=$IMG_SIZE bytes"
+  if [ "$UPDATE" = true ]; then
+    debug 'DEBUG' "Running: stat -c %s $IMG_FILE"
+    IMG_SIZE=$(stat -c %s "$IMG_FILE")
+    debug 'DEBUG' "IMG_SIZE=$IMG_SIZE bytes"
+  fi
 
   # Boot partition exists
   if grep -q 'boot' /etc/fstab; then
 
     # ext4 & f2fs
     if [ "$FSTYPE" == 'ext4' ] || [ "$FSTYPE" == 'f2fs' ]; then
+      # I have no idea why, but if I do not put this sleep here, IMG_DEV_ROOT_PATH does not get set
       sleep 2
-      IMG_DEV_BOOT_PATH=$(lsblk -no path,uuid "$LOOP" | grep "$LOCAL_BOOT_UUID" | awk '{print $1}')
-      IMG_DEV_ROOT_PATH=$(lsblk -no path,uuid "$LOOP" | grep "$LOCAL_ROOT_UUID" | awk '{print $1}')
-      debug 'DEBUG' "IMG_DEV_BOOT_PATH=$IMG_DEV_BOOT_PATH | IMG_DEV_ROOT_PATH=$IMG_DEV_ROOT_PATH"
-      # 2s sleep is sometimes not enough, might have to do with slow network if img file is on a network share
-      if ! [ -e "$IMG_DEV_BOOT_PATH" ] || ! [ -e "$IMG_DEV_ROOT_PATH" ]; then
-        for (( i=1; i<=3; i++ )); do
-          echo -e "${Yellow}!! ${Yellow}LOOP paths can not be set, retrying in 5 seconds..."
-          debug 'WARNING' 'LOOP paths can not be set, retrying in 5 seconds'
-          debug 'WARNING' "IMG_DEV_BOOT_PATH=$IMG_DEV_BOOT_PATH | IMG_DEV_ROOT_PATH=$IMG_DEV_ROOT_PATH"
-          sleep 5
-          IMG_DEV_BOOT_PATH=$(lsblk -no path,uuid "$LOOP" | grep "$LOCAL_BOOT_UUID" | awk '{print $1}')
-          IMG_DEV_ROOT_PATH=$(lsblk -no path,uuid "$LOOP" | grep "$LOCAL_ROOT_UUID" | awk '{print $1}')
-          if [ -e "$IMG_DEV_BOOT_PATH" ] && [ -e "$IMG_DEV_ROOT_PATH" ]; then
-            echo -e "${White}## ${Green}LOOP paths found, resuming backup..."
-            debug 'INFO' "LOOP paths found, resuming backup"
-            debug 'DEBUG' "IMG_DEV_BOOT_PATH=$IMG_DEV_BOOT_PATH | IMG_DEV_ROOT_PATH=$IMG_DEV_ROOT_PATH"
-            break
-          fi
-        done
-      fi
-
-      if ! [ -e "$IMG_DEV_BOOT_PATH" ] || ! [ -e "$IMG_DEV_ROOT_PATH" ]; then
-        echo -e "${Red}!! LOOP PATHS CAN NOT BE SET!!!"
-        debug 'ERROR' 'LOOP PATHS CAN NOT BE SET'
-        exit 1
-      fi
-
-    # btrfs (old method)
-    else
-      IMG_DEV_BOOT_PATH="${LOOP}p1"
-      IMG_DEV_ROOT_PATH="${LOOP}p2"
-      debug 'DEBUG' "IMG_DEV_BOOT_PATH=$IMG_DEV_BOOT_PATH | IMG_DEV_ROOT_PATH=$IMG_DEV_ROOT_PATH"
-    fi
-
-  # No boot partition exists
-  else
-    debug 'INFO' 'No boot partition detected'
-    # I have no idea why, but if I do not put this sleep here, IMG_DEV_ROOT_PATH does not get set
-    sleep 2
-    #pause 'Press [Enter] key to continue...'
-    IMG_DEV_ROOT_PATH=$(lsblk -no path,uuid "$LOOP" | grep "$LOCAL_ROOT_UUID" | awk '{print $1}')
-    debug 'DEBUG' "IMG_DEV_ROOT_PATH=$IMG_DEV_ROOT_PATH"
-  fi
-
-  # check for btrfs subvolumes on img
-  if [ "$FSTYPE" = 'btrfs' ]; then
-    # Check for temp directory and create if needed
-    if ! [ -d "$TMP_DIR" ]; then
-      echo -e "${White}## ${IWhite}Creating temp directory..."
-      $SLEEPING
-      debug 'INFO' 'Creating temp directory'
-      debug 'DEBUG' "Running: mktemp -d -t backup-XXX"
-      TMP_DIR=$(mktemp -d -t backup-XXX)
-      debug 'DEBUG' "TMP_DIR=$TMP_DIR"
-    fi
-    $SLEEPING
-    partprobe "$LOOP"
-    declare -a fstab=( $(cat /etc/fstab | grep ' / ') )
-    debug 'INFO' 'Mounting root to find subvolumes'
-    debug 'DEBUG' "Running: mount -o ${fstab[3]} $IMG_DEV_ROOT_PATH $TMP_DIR"
-    if ! output=$(mount -o "${fstab[3]}" "$IMG_DEV_ROOT_PATH" "$TMP_DIR" 2>&1); then
-      echo -e "${Yellow}$output\n${Red}!! ROOT MOUNT FAILED!!!"
-      debug 'BREAK'
-      debug 'ERROR' "ROOT MOUNT FAILED:\n$output\n------------------------------------------------------------------------------"
-      exit 1
-    fi
-    $SLEEPING
-    debug 'DEBUG' "Running: btrfs subvolume list $TMP_DIR | awk '{print \$9}'"
-    declare -a IMG_SUBVOLUMES=( $(btrfs subvolume list "$TMP_DIR" | awk '{print $9}') )
-    debug 'DEBUG' "IMG_SUBVOLUMES=$(echo ${IMG_SUBVOLUMES[@]})"
-    debug 'DEBUG' "Running: umount $TMP_DIR"
-    umount "$TMP_DIR"
-  fi
-return 0
-}
-
-
-
-# Set shared variables
-function set_img_variables() {
-
-  # Boot partition exists
-  if grep -q 'boot' /etc/fstab; then
-    debug 'INFO' 'Separate boot partition detected'
-
-    # ext4 & f2fs
-    if [ "$FSTYPE" == 'ext4' ] || [ "$FSTYPE" == 'f2fs' ]; then
-      sleep 2
+      #pause 'Press [Enter] key to continue...'
       IMG_DEV_BOOT_PATH=$(lsblk -no path,uuid "$LOOP" | grep "$LOCAL_BOOT_UUID" | awk '{print $1}')
       IMG_DEV_ROOT_PATH=$(lsblk -no path,uuid "$LOOP" | grep "$LOCAL_ROOT_UUID" | awk '{print $1}')
       debug 'DEBUG' "IMG_DEV_BOOT_PATH=$IMG_DEV_BOOT_PATH | IMG_DEV_ROOT_PATH=$IMG_DEV_ROOT_PATH"
@@ -639,8 +566,9 @@ function set_img_variables() {
 
   # No boot partition exists
   else
-    debug 'INFO' 'No boot partition detected'
+    # I have no idea why, but if I do not put this sleep here, IMG_DEV_ROOT_PATH does not get set
     sleep 2
+    #pause 'Press [Enter] key to continue...'
     IMG_DEV_ROOT_PATH=$(lsblk -no path,uuid "$LOOP" | grep "$LOCAL_ROOT_UUID" | awk '{print $1}')
     debug 'DEBUG' "IMG_DEV_ROOT_PATH=$IMG_DEV_ROOT_PATH"
     # 2s sleep is sometimes not enough, might have to do with slow network if img file is on a network share
@@ -666,6 +594,37 @@ function set_img_variables() {
       exit 1
     fi
   fi
+
+  # Check for btrfs subvolumes on img
+  # None of this is needed unless creation of new voumes during update will be implemented
+  if [ "$FSTYPE" = 'btrfs' ] && [ "$UPDATE" = true ]; then
+    # Check for temp directory and create if needed
+    if ! [ -d "$TMP_DIR" ]; then
+      echo -e "${White}## ${IWhite}Creating temp directory..."
+      $SLEEPING
+      debug 'INFO' 'Creating temp directory'
+      debug 'DEBUG' "Running: mktemp -d -t backup-XXX"
+      TMP_DIR=$(mktemp -d -t backup-XXX)
+      debug 'DEBUG' "TMP_DIR=$TMP_DIR"
+    fi
+    $SLEEPING
+    partprobe "$LOOP"
+    declare -a fstab=( $(cat /etc/fstab | grep ' / ') )
+    debug 'INFO' 'Mounting btrfs filesystem to find subvolumes'
+    debug 'DEBUG' "Running: mount -o ${fstab[3]} $IMG_DEV_ROOT_PATH $TMP_DIR"
+    if ! output=$(mount -o "${fstab[3]}" "$IMG_DEV_ROOT_PATH" "$TMP_DIR" 2>&1); then
+      echo -e "${Yellow}$output\n${Red}!! ROOT MOUNT FAILED!!!"
+      debug 'BREAK'
+      debug 'ERROR' "ROOT MOUNT FAILED:\n$output\n-------------------------------------------------------------------------------------"
+      exit 1
+    fi
+    $SLEEPING
+    debug 'DEBUG' "Running: btrfs subvolume list $TMP_DIR | awk '{print \$9}'"
+    declare -a IMG_SUBVOLUMES=( $(btrfs subvolume list "$TMP_DIR" | awk '{print $9}') )
+    debug 'DEBUG' "IMG_SUBVOLUMES=$(echo ${IMG_SUBVOLUMES[@]})"
+    debug 'DEBUG' "Running: umount $TMP_DIR"
+    umount "$TMP_DIR"
+  fi
 return 0
 }
 
@@ -685,7 +644,7 @@ function do_loop() {
   if ! output=$(losetup -P "$LOOP" "$IMG_FILE" 2>&1); then
     echo -e "${Yellow}$output\n${Red}!! LOSETUP FAILED!!!"
     debug 'BREAK'
-    debug 'ERROR' "LOSETUP FAILED:\n$output\n------------------------------------------------------------------------------"
+    debug 'ERROR' "LOSETUP FAILED:\n$output\n-------------------------------------------------------------------------------------"
     exit 1
   fi
 return 0
@@ -693,7 +652,7 @@ return 0
 
 
 
-# mount img file
+# Mount img file
 function do_mount() {
 
   # Check for temp directory and create if needed
@@ -717,7 +676,7 @@ function do_mount() {
     if ! output=$(mount "$IMG_DEV_ROOT_PATH" "$TMP_DIR" 2>&1); then
       echo -e "${Yellow}$output\n${Red}!! ROOT MOUNT FAILED!!!"
       debug 'BREAK'
-      debug 'ERROR' "ROOT MOUNT FAILED:\n$output\n------------------------------------------------------------------------------"
+      debug 'ERROR' "ROOT MOUNT FAILED:\n$output\n-------------------------------------------------------------------------------------"
       exit 1
     fi
 
@@ -729,14 +688,33 @@ function do_mount() {
     if ! output=$(mount -o "${fstab[3]}" "$IMG_DEV_ROOT_PATH" "$TMP_DIR" 2>&1); then
       echo -e "${Yellow}$output\n${Red}!! ROOT SUBVOLUME MOUNT FAILED!!!"
       debug 'BREAK'
-      debug 'ERROR' "ROOT SUBVOLUME MOUNT FAILED:\n$output\n------------------------------------------------------------------------------"
+      debug 'ERROR' "ROOT SUBVOLUME MOUNT FAILED:\n$output\n-------------------------------------------------------------------------------------"
       exit 1
     fi
     $SLEEPING
 
+    # New volumes will not be created during an update
+    # Overhaul, test this instead:
+#     for subvol in "${LOCAL_SUBVOLUMES[@]}"; do
+#       # Excluding root (@) subvolume and mounting all else in fstab, nested volumes are not in fstab
+#       if grep -q "$subvol" /etc/fstab && [[ "$subvol" != '@' ]]; then
+#         declare -a fstab=( $(cat /etc/fstab | grep "$subvol") )
+#         echo -e "${White}## ${IWhite}Mounting subvolume: ${Green}$subvol"
+#         debug 'DEBUG' "Running: mount -o ${fstab[3]} $IMG_DEV_ROOT_PATH ${TMP_DIR}${fstab[1]}"
+#         if ! output=$(mount -o "${fstab[3]}" "$IMG_DEV_ROOT_PATH" "${TMP_DIR}${fstab[1]}" 2>&1); then
+#           echo -e "${Yellow}$output\n${Red}!! SUBVOLUME MOUNT FAILED!!!"
+#           debug 'BREAK'
+#           debug 'ERROR' "SUBVOLUME MOUNT FAILED:\n$output\n-------------------------------------------------------------------------------------"
+#           exit 1
+#         fi
+#       fi
+#       $SLEEPING
+#     done
+
     for ((i = 0; i < ${#LOCAL_SUBVOLUMES[@]}; i++)); do
       subvol_path="${LOCAL_SUBVOLUMES[i]}"
       #if $(cat /etc/fstab | grep -q "$subvol_path") && [[ "$subvol_path" != '@' ]]; then
+      # Excluding root (@) subvolume and mounting all else in fstab, nested volumes are not in fstab
       if grep -q "$subvol_path" /etc/fstab && [[ "$subvol_path" != '@' ]]; then
         declare -a fstab=( $(cat /etc/fstab | grep "$subvol_path") )
         if ! [ -d "${TMP_DIR}${fstab[1]}" ]; then
@@ -748,10 +726,11 @@ function do_mount() {
         if ! output=$(mount -o "${fstab[3]}" "$IMG_DEV_ROOT_PATH" ${TMP_DIR}${fstab[1]} 2>&1); then
           echo -e "${Yellow}$output\n${Red}!! SUBVOLUME MOUNT FAILED!!!"
           debug 'BREAK'
-          debug 'ERROR' "SUBVOLUME MOUNT FAILED:\n$output\n------------------------------------------------------------------------------"
+          debug 'ERROR' "SUBVOLUME MOUNT FAILED:\n$output\n-------------------------------------------------------------------------------------"
           exit 1
         fi
 
+      # Make sure directories exist for nested volumes
       elif [[ "$subvol_path" != '@'* ]]; then
         if ! [ -d "${TMP_DIR}/${subvol_path}" ]; then
           debug 'DEBUG' "Running: mkdir -p ${TMP_DIR}/${subvol_path}"
@@ -771,7 +750,7 @@ function do_mount() {
     fi
     echo -e "${White}## ${IWhite}Mounting img boot partition..."
     $SLEEPING
-    debug 'INFO' 'Separate boot partition detected, mounting boot inside root'
+    debug 'INFO' 'Mounting boot inside root'
     if ! [ -d ${TMP_DIR}${BOOT_PATH} ]; then
       debug 'INFO' 'Boot directory did not exist on img'
       debug 'DEBUG' "Running: mkdir -p ${TMP_DIR}${BOOT_PATH}"
@@ -781,7 +760,7 @@ function do_mount() {
     if ! output=$(mount "$IMG_DEV_BOOT_PATH" "${TMP_DIR}${BOOT_PATH}" 2>&1); then
       echo -e "${Yellow}$output\n${Red}!! BOOT MOUNT FAILED!!!"
       debug 'BREAK'
-      debug 'ERROR' "BOOT MOUNT FAILED:\n$output\n------------------------------------------------------------------------------"
+      debug 'ERROR' "BOOT MOUNT FAILED:\n$output\n-------------------------------------------------------------------------------------"
       exit 1
     fi
   fi
@@ -813,7 +792,7 @@ function do_e2fsck() {
     output=$(e2fsck -p -f -v "$IMG_DEV_ROOT_PATH" 2>&1)
     echo "$output"
     debug 'BREAK'
-    debug 'DEBUG' "Running: e2fsck -p -f -v $IMG_DEV_ROOT_PATH\n$output\n------------------------------------------------------------------------------"
+    debug 'DEBUG' "Running: e2fsck -p -f -v $IMG_DEV_ROOT_PATH\n$output\n-------------------------------------------------------------------------------------"
     $SLEEPING
 
     # Remounting if autoexpansion is requested
@@ -832,7 +811,7 @@ function do_e2fsck() {
 
     output=$(e2fsck -p -f "$IMG_DEV_ROOT_PATH" 2>&1)
     echo "$output"
-    debug 'DEBUG' "Running: e2fsck -p -f $IMG_DEV_ROOT_PATH\n$output\n------------------------------------------------------------------------------"
+    debug 'DEBUG' "Running: e2fsck -p -f $IMG_DEV_ROOT_PATH\n$output\n-------------------------------------------------------------------------------------"
     $SLEEPING
   fi
 
@@ -888,7 +867,7 @@ function do_resize() {
     if ! output=$(truncate --size="$TRUNCATE_TOTAL" "$IMG_FILE" 2>&1); then
       echo -e "${Yellow}$output\n${Red}!! TRUNCATE FAILED!!!"
       debug 'BREAK'
-      debug 'ERROR' "TRUNCATE FAILED:\n$output\n------------------------------------------------------------------------------"
+      debug 'ERROR' "TRUNCATE FAILED:\n$output\n-------------------------------------------------------------------------------------"
       exit 1
     fi
 
@@ -911,8 +890,8 @@ function do_resize() {
       #echo -e "${Yellow}$output\n${Red}!! SFDISK FAILED!!!"
       echo -e "${Yellow}$output\n${Red}!! PARTED FAILED!!!"
       debug 'BREAK'
-      #debug 'ERROR' "SFDISK FAILED:\n$output\n------------------------------------------------------------------------------"
-      debug 'ERROR' "PARTED FAILED:\n$output\n------------------------------------------------------------------------------"
+      #debug 'ERROR' "SFDISK FAILED:\n$output\n-------------------------------------------------------------------------------------"
+      debug 'ERROR' "PARTED FAILED:\n$output\n-------------------------------------------------------------------------------------"
       exit 1
     fi
 
@@ -923,7 +902,7 @@ function do_resize() {
     if ! output=$(parted -s -a none "$LOOP" unit B mkpart primary ext4 "$IMG_ROOT_START" 100% 2>&1); then
       echo -e "${Yellow}$output\n${Red}!! PARTED FAILED!!!"
       debug 'BREAK'
-      debug 'ERROR' "PARTED FAILED:\n$output\n------------------------------------------------------------------------------"
+      debug 'ERROR' "PARTED FAILED:\n$output\n-------------------------------------------------------------------------------------"
       exit 1
     fi
 
@@ -935,10 +914,10 @@ function do_resize() {
     if ! output=$(resize2fs -p -f "$IMG_DEV_ROOT_PATH" 2>&1); then
       echo -e "${Yellow}$output\n${Red}!! RESIZE2FS FAILED!!!"
       debug 'BREAK'
-      debug 'ERROR' "RESIZE2FS FAILED:\n$output\n------------------------------------------------------------------------------"
+      debug 'ERROR' "RESIZE2FS FAILED:\n$output\n-------------------------------------------------------------------------------------"
       exit 1
     fi
-    debug 'DEBUG' "$output\n------------------------------------------------------------------------------"
+    debug 'DEBUG' "$output\n-------------------------------------------------------------------------------------"
 
     # Check img filesystem
     debug 'INFO' 'Running function: do_e2fsck'
@@ -956,10 +935,10 @@ function do_resize() {
     if ! output=$(resize2fs -p -f "$IMG_DEV_ROOT_PATH" "$TOTALK"K 2>&1 | tee "$TTY_AVAILABILITY"); then
       echo -e "${Red}$output\n${Red}!! RESIZE2FS FAILED!!!"
       debug 'BREAK'
-      debug 'ERROR' "RESIZE2FS FAILED:\n$output\n------------------------------------------------------------------------------"
+      debug 'ERROR' "RESIZE2FS FAILED:\n$output\n-------------------------------------------------------------------------------------"
       exit 1
     fi
-    debug 'DEBUG' "$output\n------------------------------------------------------------------------------"
+    debug 'DEBUG' "$output\n-------------------------------------------------------------------------------------"
 
     echo -e "${White}## ${IWhite}Shrinking partition..."
     $SLEEPING
@@ -972,10 +951,10 @@ function do_resize() {
     if ! output=$(printf 'Yes\n' | parted -a none "$LOOP" unit B resizepart "$IMG_ROOT_PARTN" "$TRUNCATE_TOTAL" ---pretend-input-tty 2>&1); then
       echo -e "${Yellow}$output\n${Red}!! PARTED FAILED!!!"
       debug 'BREAK'
-      debug 'ERROR' "PARTED FAILED:\n$output\n------------------------------------------------------------------------------"
+      debug 'ERROR' "PARTED FAILED:\n$output\n-------------------------------------------------------------------------------------"
       exit 1
     fi
-    debug 'DEBUG' "$output\n------------------------------------------------------------------------------"
+    debug 'DEBUG' "$output\n-------------------------------------------------------------------------------------"
 
     echo -e "${White}## ${IWhite}Shrinking img file..."
     $SLEEPING
@@ -984,7 +963,7 @@ function do_resize() {
     if ! output=$(truncate --size="$TRUNCATE_TOTAL" "$IMG_FILE" 2>&1); then
       echo -e "${Yellow}$output\n${Red}!! TRUNCATE FAILED!!!"
       debug 'BREAK'
-      debug 'ERROR' "TRUNCATE FAILED:\n$output\n------------------------------------------------------------------------------"
+      debug 'ERROR' "TRUNCATE FAILED:\n$output\n-------------------------------------------------------------------------------------"
       exit 1
     fi
 
@@ -1021,15 +1000,6 @@ function do_rsync() {
     else
       rsync -ahvHAX --exclude-from="$EXCLUDE_FILE_LOCATION" --exclude={${IMG_PATH}/*,${TMP_DIR},${tmp_file}} --info=progress2 --stats "$RSYNC_DELETE" --force --partial --delete-excluded --timeout=10 / "$TMP_DIR" 2>&1 | tee /dev/null > "$tmp_file"
     fi
-#     if [ "${PIPESTATUS[0]}" -ne 0 ] && [ "${PIPESTATUS[0]}" -ne 23 ]; then # code 23 = rsync warning: some files vanished before they could be transferred (code 24) at main.c
-#       output=$(tail -16 "$tmp_file")
-#       echo -e "${Yellow}$output\n${Red}!! RSYNC FAILED!!!"
-#       debug 'BREAK'
-#       debug 'ERROR' "RSYNC FAILED:\n$output\n------------------------------------------------------------------------------"
-#       exit 6
-#     elif [ "${PIPESTATUS[0]}" -eq 23 ]; then
-#       debug 'WARNING' 'rsync code 23, some files vanished before they could be transferred (code 24) at main.c'
-#     fi
   else
     debug 'DEBUG' "Running: rsync -ahvHAX --exclude={/lost+found,/proc/*,/sys/*,/dev/*,/tmp/*,/run/*,/mnt/*,/media/*,/var/swap,${IMG_PATH}/*} --info=progress2 --stats "$RSYNC_DELETE" --force --partial --delete-excluded --timeout=10 / $TMP_DIR"
     if [ "$RSYNC_TTY" = true ]; then
@@ -1037,15 +1007,6 @@ function do_rsync() {
     else
       rsync -ahvHAX --exclude={/lost+found,/proc/*,/sys/*,/dev/*,/tmp/*,/run/*,/mnt/*,/media/*,/var/swap,${IMG_PATH}/*} --info=progress2 --stats "$RSYNC_DELETE" --force --partial --delete-excluded --timeout=10 / "$TMP_DIR" 2>&1 | tee /dev/null > "$tmp_file"
     fi
-#     if [ "${PIPESTATUS[0]}" -ne 0 ] && [ "${PIPESTATUS[0]}" -ne 23 ]; then # code 23 = rsync warning: some files vanished before they could be transferred (code 24) at main.c
-#       output=$(tail -16 "$tmp_file")
-#       echo -e "${Yellow}$output\n${Red}!! RSYNC FAILED!!!"
-#       debug 'BREAK'
-#       debug 'ERROR' "RSYNC FAILED:\n$output\n------------------------------------------------------------------------------"
-#       exit 6
-#     elif [ "${PIPESTATUS[0]}" -eq 23 ]; then
-#       debug 'WARNING' 'rsync code 23, some files vanished before they could be transferred (code 24) at main.c'
-#     fi
   fi
 
   # Get the exit status of rsync from PIPESTATUS
@@ -1053,7 +1014,7 @@ function do_rsync() {
     output=$(tail -16 "$tmp_file")
     echo -e "${Yellow}$output\n${Red}!! RSYNC FAILED!!!"
     debug 'BREAK'
-    debug 'ERROR' "RSYNC FAILED:\nPIPESTATUS=${PIPESTATUS[0]}\n$output\n------------------------------------------------------------------------------"
+    debug 'ERROR' "RSYNC FAILED:\nPIPESTATUS=${PIPESTATUS[0]}\n$output\n-------------------------------------------------------------------------------------"
     exit 6
   elif [ "${PIPESTATUS[0]}" -eq 23 ]; then
     echo -e "${White}## ${Yellow}Warning, rsync code 23, some files vanished before they could be transferred (code 24) at main.c"
@@ -1065,7 +1026,7 @@ function do_rsync() {
   echo -e "${White}## ${IWhite}Please stand by..."
   output=$(tail -16 "$tmp_file")
   debug 'BREAK'
-  debug 'DEBUG' "Rsync report:\n$output\n------------------------------------------------------------------------------"
+  debug 'DEBUG' "Rsync report:\n$output\n-------------------------------------------------------------------------------------"
   debug 'INFO' 'Rsync done'
   sleep 4
 return 0
@@ -1076,8 +1037,8 @@ return 0
 # Create a backup img file
 function make_img() {
 
-  debug 'INFO' 'Running function: get_dev_variables'
-  get_dev_variables
+  debug 'INFO' 'Running function: dev_variables'
+  dev_variables
 
   # Display information
   echo -e "${Purple}$BREAK"
@@ -1098,40 +1059,40 @@ function make_img() {
     echo -e "# ${Yellow}Converting filesystem into ${Green}f2fs ${Yellow}on img file ${Purple}$(printf "%+$(( COLS - 46 ))s" '#')"
     echo -e "# ${Yellow}Autoexpand filesystem at boot not available for ${Green}f2fs ${Purple}$(printf "%+$(( COLS - 55 ))s" '#')"
   fi
-  echo -e "${Purple}# --------------------------------------------------------------------------------- #"
+  echo -e "${Purple}# $(printf %$(( COLS - 4 ))s | tr ' ' '-') #"
   echo -e "# ${IWhite}Write to logfile:              ${Green}$DEBUG ${Purple}$(printf "%+$(( COLS - 33 - $(echo ${DEBUG} | wc -m ) ))s" '#')"
   echo -e "# ${IWhite}Zoom speed requested:          ${Green}$ZOOM ${Purple}$(printf "%+$(( COLS - 33 - $(echo ${ZOOM} | wc -m ) ))s" '#')"
   echo -e "# ${IWhite}rsync tty output:              ${Green}$RSYNC_TTY ${Purple}$(printf "%+$(( COLS - 33 - $(echo ${RSYNC_TTY} | wc -m ) ))s" '#')"
   echo -e "# ${IWhite}Autocalculate img root size:   ${Green}$AUTORESIZE_RUN ${Purple}$(printf "%+$(( COLS - 33 - $(echo ${AUTORESIZE_RUN} | wc -m ) ))s" '#')"
   echo -e "# ${IWhite}Autoexpand filesystem at boot: ${Green}$AUTOEXPAND ${Purple}$(printf "%+$(( COLS - 33 - $(echo ${AUTOEXPAND} | wc -m ) ))s" '#')"
   echo -e "# ${IWhite}Use exclude.txt:               ${Green}$EXCLUDE_FILE ${Purple}$(printf "%+$(( COLS - 33 - $(echo ${EXCLUDE_FILE} | wc -m ) ))s" '#')"
+  echo -e "# ${IWhite}Boot partition:                ${Green}$BOOT_PARTITION ${Purple}$(printf "%+$(( COLS - 33 - $(echo ${BOOT_PARTITION} | wc -m ) ))s" '#')"
   print_temp="$(( LOCAL_BOOTSECTOR / 1024 / 1024 ))"
   echo -e "# ${IWhite}Bootsector size:               ${Green}${print_temp}MiB ${Purple}$(printf "%+$(( COLS - 36 - $(echo ${print_temp} | wc -m ) ))s" '#')"
   print_temp="$(( $(df / -k --sync --output=used | tail -1) / 1024 ))"
-  echo -e "# ${IWhite}Estemated root usage:          ${Green}${print_temp}MiB ${Purple}$(printf "%+$(( COLS - 36 - $(echo ${print_temp} | wc -m ) ))s" '#')"
+  echo -e "# ${IWhite}Estimated root usage:          ${Green}${print_temp}MiB ${Purple}$(printf "%+$(( COLS - 36 - $(echo ${print_temp} | wc -m ) ))s" '#')"
   if [ "$AUTORESIZE_RUN" = true ]; then
     print_temp="$(( LOCAL_AUTORESIZE_MIN / 1024 / 1024 ))"
     echo -e "# ${IWhite}Auto calculated root size:     ${Green}${print_temp}MiB ${Purple}$(printf "%+$(( COLS - 36 - $(echo ${print_temp} | wc -m ) ))s" '#')"
     print_temp="$(( TRUNCATE_TOTAL / 1024 / 1024 ))"
     echo -e "# ${IWhite}Total img size:                ${Green}${print_temp}MiB ${Purple}$(printf "%+$(( COLS - 36 - $(echo ${print_temp} | wc -m ) ))s" '#')"
   else
-    print_temp="$(( ADDED_SPACE / 1024 / 1024 ))"
-    echo -e "# ${IWhite}Manually added space:          ${Green}${print_temp}MiB ${Purple}$(printf "%+$(( COLS - 36 - $(echo ${print_temp} | wc -m ) ))s" '#')"
-    print_temp2="$(( TRUNCATE_TOTAL / 1024 / 1024 ))"
-    echo -e "# ${IWhite}Total img size:                ${Green}${print_temp2}MiB ${IWhite}with ${Green}${print_temp}MiB [extra space] ${IWhite}included ${Purple}$(printf "%+$(( COLS - 67 - $(echo ${print_temp2} | wc -m ) - $(echo ${print_temp} | wc -m ) ))s" '#')"
+    print_temp="$(( TRUNCATE_TOTAL / 1024 / 1024 ))"
+    print_temp2="$(( ADDED_SPACE / 1024 / 1024 ))"
+    echo -e "# ${IWhite}Total img size:                ${Green}${print_temp}MiB ${IWhite}with ${Green}${print_temp2}MiB [extra space] ${IWhite}included ${Purple}$(printf "%+$(( COLS - 67 - $(echo ${print_temp} | wc -m ) - $(echo ${print_temp2} | wc -m ) ))s" '#')"
     if [ "$AUTORESIZE_WARNING" = true ]; then
-      echo -e "${Yellow}# --------------------------------------------------------------------------------- #"
+      echo -e "${Yellow}# $(printf %$(( COLS - 4 ))s | tr ' ' '-') #"
       echo -e "! WARNING!!! Manually added space is smaller than calculated recommended minimum $(printf "%+$(( COLS - 81 ))s" '!')"
       echo -e "! This does NOT mean the backup WILL fail, but CAN fail due to lack of space $(printf "%+$(( COLS - 77 ))s" '!')"
       echo -e "! Consider using the -a option or manually adding more space $(printf "%+$(( COLS - 61 ))s" '!')"
       print_temp="$(( LOCAL_AUTORESIZE_MIN / 1024 / 1024 ))"
-      echo -e "! ${IWhite}Calculated recommended minimum: ${Green}${print_temp}MiB ${Yellow}$(printf "%+$(( COLS - 37 - $(echo ${print_temp} | wc -m ) ))s" '!')"
+      echo -e "! ${IWhite}Calculated recommended minimum: ${Green}${print_temp}MiB ${Yellow}$(printf "%+$(( COLS - 36 - $(echo ${print_temp} | wc -m ) ))s" '!')"
       print_temp="$(( TOTAL / 1024 / 1024 ))"
       echo -e "! ${IWhite}Requested root size:            ${Yellow}${print_temp}MiB $(printf "%+$(( COLS - 37 - $(echo ${print_temp} | wc -m ) ))s" '!')"
     fi
   fi
   if [ "$F2FS" = true ]; then
-    echo -e "${Yellow}# --------------------------------------------------------------------------------- #"
+    echo -e "${Yellow}# $(printf %$(( COLS - 4 ))s | tr ' ' '-') #"
     echo -e "! WARNING!!! --f2fs option selected. f2fs filesystem will be created on img file $(printf "%+$(( COLS - 81 ))s" '!')"
     echo -e "! This option is only for CONVERTING existing filesystem into f2fs on img file $(printf "%+$(( COLS - 79 ))s" '!')"
     echo -e "! This option is NOT needed for normal backups from f2fs on root $(printf "%+$(( COLS - 65 ))s" '!')"
@@ -1149,21 +1110,17 @@ function make_img() {
   # Confirm with user input
   elif [ "$PROMPTS" = true ]; then
     echo -e "${Purple}${BREAK}${IWhite}"
-#     read -p "Do you want to continue? [y/n] " -n 1 -r
-#     debug 'INFO' 'Do you want to continue? [y/n]'
-#     if ! [[ "$REPLY" =~ ^[Yy]$ ]]; then
-#       echo ''
-#       echo '## Aborting...'
-#       exit 4
-#     fi
-#     echo ''
     debug 'INFO' 'Do you want to continue? [y/n]'
     while true; do
-      read -n 1 -r -p '## Do you want to continue? [y/n] ' input
+      if [ "$COLORS" = true ]; then
+        read -r -p $'\e[0;37m## \e[0;97mDo you want to continue? \e[0;92m[y/n] \e[0m' input
+      else
+        read -r -p '## Do you want to continue? [y/n] ' input
+      fi
       case $input in
-        [Yy]) echo -e '\n'; break;;
-        [Nn]) echo -e "\n${Red}!! Aborting..."; exit 4;;
-        *) echo -e "\n${Yellow}!! ${Red}ERROR! ${Yellow}Please enter ${Green}'y/Y' ${Yellow}or ${Green}'n/N'${Yellow}"; debug 'WARNING' "ERROR, please enter 'y/Y' or 'n/N'";;
+        [Yy]) break;;
+        [Nn]) echo -e "${Red}!! Aborting..."; exit 4;;
+        *) echo -e "${Yellow}!! ${Red}ERROR! ${Yellow}Please enter ${Green}'y' ${Yellow}or ${Green}'n'${Yellow}"; debug 'WARNING' "ERROR, please enter 'y' or 'n'";;
       esac
     done
     debug 'INFO' 'Y or y pressed to confirm'
@@ -1176,11 +1133,15 @@ function make_img() {
       echo -e "${Yellow}!! FILE ALREADY EXISTS!!!"
       debug 'WARNING' 'Do you want to overwrite? [y/n]'
       while true; do
-        read -n 1 -r -p '!! Do you want to overwrite? [y/n] ' input
+        if [ "$COLORS" = true ]; then
+          read -r -p $'\e[0;37m## \e[0;97mDo you want to overwrite? \e[0;92m[y/n] \e[0m' input
+        else
+          read -r -p '## Do you want to overwrite? [y/n] ' input
+        fi
         case $input in
-          [Yy]) echo -e '\n'; break;;
-          [Nn]) echo -e "\n${Red}!! Aborting..."; exit 4;;
-          *) echo -e "\n${Yellow}!! ${Red}ERROR! ${Yellow}Please enter ${Green}'y/Y' ${Yellow}or ${Green}'n/N'${Yellow}"; debug 'WARNING' "ERROR, please enter 'y/Y' or 'n/N'";;
+          [Yy]) break;;
+          [Nn]) echo -e "${Red}!! Aborting..."; exit 4;;
+          *) echo -e "${Yellow}!! ${Red}ERROR! ${Yellow}Please enter ${Green}'y' ${Yellow}or ${Green}'n'${Yellow}"; debug 'WARNING' "ERROR, please enter 'y' or 'n'";;
         esac
       done
       debug 'WARNING' 'Overwrite confirmed by user'
@@ -1208,12 +1169,12 @@ function make_img() {
   if ! output=$(dd bs=512 count=$LOCAL_DDBOOTSECTOR if="$LOCAL_DEV_PATH" of="$IMG_FILE" conv=noerror,fsync status=progress 2>&1 | tee "$TTY_AVAILABILITY") && sync; then
     echo -e "${Yellow}$output\n${Red}!! DD TO LOCAL_BOOTSECTOR FAILED!!!"
     debug 'BREAK'
-    debug 'ERROR' "DD TO LOCAL_BOOTSECTOR FAILED:\n$output\n------------------------------------------------------------------------------"
+    debug 'ERROR' "DD TO LOCAL_BOOTSECTOR FAILED:\n$output\n-------------------------------------------------------------------------------------"
     exit 1
   fi
   output=$(echo "$output" | tail -3 )
   debug 'BREAK'
-  debug 'DEBUG' "dd completed:\n$output\n------------------------------------------------------------------------------"
+  debug 'DEBUG' "dd completed:\n$output\n-------------------------------------------------------------------------------------"
   $SLEEPING
 
   # Truncate file to correct size
@@ -1224,7 +1185,7 @@ function make_img() {
   if ! output=$(truncate --size="$TRUNCATE_TOTAL" "$IMG_FILE" 2>&1); then
     echo -e "${Yellow}$output\n${Red}!! TRUNCATE FAILED!!!"
     debug 'BREAK'
-    debug 'ERROR' "TRUNCATE FAILED:\n$output\n------------------------------------------------------------------------------"
+    debug 'ERROR' "TRUNCATE FAILED:\n$output\n-------------------------------------------------------------------------------------"
     exit 1
   fi
   $SLEEPING
@@ -1234,8 +1195,8 @@ function make_img() {
   do_loop
 
   # set img variables
-  debug 'INFO' 'Running function: set_img_variables'
-  set_img_variables
+  debug 'INFO' 'Running function: img_variables'
+  img_variables
 
   # Remove partition
   echo -e "${White}## ${IWhite}Removing root partition..."
@@ -1304,7 +1265,7 @@ function make_img() {
     if ! output=$(sgdisk "$LOOP" -d "$LOCAL_ROOT_PARTN" 2>&1); then
       echo -e "${Yellow}$output\n${Red}!! SGDISK FAILED!!!"
       debug 'BREAK'
-      debug 'ERROR' "SGDISK FAILED:\n$output\n------------------------------------------------------------------------------"
+      debug 'ERROR' "SGDISK FAILED:\n$output\n-------------------------------------------------------------------------------------"
       exit 1
     fi
 
@@ -1323,8 +1284,8 @@ function make_img() {
       echo -e "${Yellow}$output\n${Red}!! SFDISK FAILED!!!"
       #echo -e "${Yellow}$output\n${Red}!! PARTED FAILED!!!"
       debug 'BREAK'
-      debug 'ERROR' "SFDISK FAILED:\n$output\n------------------------------------------------------------------------------"
-      #debug 'ERROR' "PARTED FAILED:\n$output\n------------------------------------------------------------------------------"
+      debug 'ERROR' "SFDISK FAILED:\n$output\n-------------------------------------------------------------------------------------"
+      #debug 'ERROR' "PARTED FAILED:\n$output\n-------------------------------------------------------------------------------------"
       exit 1
     fi
   fi
@@ -1342,28 +1303,29 @@ function make_img() {
     if ! output=$(parted -s -a none "$LOOP" unit B mkpart primary f2fs "$LOCAL_ROOT_START" 100% 2>&1); then
       echo -e "${Yellow}$output\n${Red}!! PARTED FAILED!!!"
       debug 'BREAK'
-      debug 'ERROR' "PARTED FAILED:\n$output\n------------------------------------------------------------------------------"
+      debug 'ERROR' "PARTED FAILED:\n$output\n-------------------------------------------------------------------------------------"
       exit 1
     fi
 
   # ext4 or f2fs on root
   elif [ "$FSTYPE" == 'ext4' ] || [ "$FSTYPE" == 'f2fs' ]; then
     debug 'DEBUG' "Running: parted -s -a none $LOOP unit B mkpart primary $LOCAL_ROOT_START 100%"
+    # Figure out why I am not using below line for ALL filesystems unless converting
     #if ! output=$(parted -s -a none "$LOOP" unit B mkpart primary "$FSTYPE" "$LOCAL_ROOT_START" 100% 2>&1); then
     if ! output=$(parted -s -a none "$LOOP" unit B mkpart primary "$LOCAL_ROOT_START" 100% 2>&1); then
       echo -e "${Yellow}$output\n${Red}!! PARTED FAILED!!!"
       debug 'BREAK'
-      debug 'ERROR' "PARTED FAILED:\n$output\n------------------------------------------------------------------------------"
+      debug 'ERROR' "PARTED FAILED:\n$output\n-------------------------------------------------------------------------------------"
       exit 1
     fi
 
   # btrfs
-  else
+  elif [ "$FSTYPE" == 'btrfs' ]; then
     debug 'DEBUG' "Running: parted -s -a none $LOOP unit B mkpart primary btrfs $LOCAL_ROOT_START 100%"
     if ! output=$(parted -s -a none "$LOOP" unit B mkpart primary btrfs "$LOCAL_ROOT_START" 100% 2>&1); then
       echo -e "${Yellow}$output\n${Red}!! PARTED FAILED!!!"
       debug 'BREAK'
-      debug 'ERROR' "PARTED FAILED:\n$output\n------------------------------------------------------------------------------"
+      debug 'ERROR' "PARTED FAILED:\n$output\n-------------------------------------------------------------------------------------"
       exit 1
     fi
   fi
@@ -1406,11 +1368,11 @@ function make_img() {
     if ! output=$(mkfs.f2fs -f -U "$UUID" -l "$LABEL" "$IMG_DEV_ROOT_PATH" 2>&1 | tee "$TTY_AVAILABILITY" ); then
       echo -e "${Yellow}$output\n${Red}!! MKFS.F2FS FAILED!!!"
       debug 'BREAK'
-      debug 'ERROR' "MKFS.F2FS FAILED:\n$output\n------------------------------------------------------------------------------"
+      debug 'ERROR' "MKFS.F2FS FAILED:\n$output\n-------------------------------------------------------------------------------------"
       exit 1
     fi
     debug 'BREAK'
-    debug 'DEBUG' "Running: mkfs.f2fs -f -U $UUID -l $LABEL $IMG_DEV_ROOT_PATH\n$output\n------------------------------------------------------------------------------"
+    debug 'DEBUG' "Running: mkfs.f2fs -f -U $UUID -l $LABEL $IMG_DEV_ROOT_PATH\n$output\n-------------------------------------------------------------------------------------"
     $SLEEPING
 
     debug 'INFO' 'Running function: do_mount'
@@ -1422,11 +1384,11 @@ function make_img() {
     if ! output=$(mkfs.ext4 -U "$UUID" -L "$LABEL" "$IMG_DEV_ROOT_PATH" 2>&1 | tee "$TTY_AVAILABILITY" ); then
       echo -e "${Yellow}$output\n${Red}!! MKFS.EXT4 FAILED!!!"
       debug 'BREAK'
-      debug 'ERROR' "MKFS.EXT4 FAILED:\n$output\n------------------------------------------------------------------------------"
+      debug 'ERROR' "MKFS.EXT4 FAILED:\n$output\n-------------------------------------------------------------------------------------"
       exit 1
     fi
     debug 'BREAK'
-    debug 'DEBUG' "Running: mkfs.$FSTYPE -U $UUID -L $LABEL $IMG_DEV_ROOT_PATH\n$output\n------------------------------------------------------------------------------"
+    debug 'DEBUG' "Running: mkfs.$FSTYPE -U $UUID -L $LABEL $IMG_DEV_ROOT_PATH\n$output\n-------------------------------------------------------------------------------------"
     $SLEEPING
 
     debug 'INFO' 'Running function: do_e2fsck'
@@ -1441,11 +1403,11 @@ function make_img() {
     if ! output=$(mkfs.f2fs -f -U "$UUID" -l "$LABEL" "$IMG_DEV_ROOT_PATH" 2>&1 | tee "$TTY_AVAILABILITY" ); then
       echo -e "${Yellow}$output\n${Red}!! MKFS.F2FS FAILED!!!"
       debug 'BREAK'
-      debug 'ERROR' "MKFS.F2FS FAILED:\n$output\n------------------------------------------------------------------------------"
+      debug 'ERROR' "MKFS.F2FS FAILED:\n$output\n-------------------------------------------------------------------------------------"
       exit 1
     fi
     debug 'BREAK'
-    debug 'DEBUG' "Running: mkfs.f2fs -f -U $UUID -l $LABEL $IMG_DEV_ROOT_PATH\n$output\n------------------------------------------------------------------------------"
+    debug 'DEBUG' "Running: mkfs.f2fs -f -U $UUID -l $LABEL $IMG_DEV_ROOT_PATH\n$output\n-------------------------------------------------------------------------------------"
     $SLEEPING
 
     debug 'INFO' 'Running function: do_mount'
@@ -1455,14 +1417,14 @@ function make_img() {
   elif [ "$FSTYPE" == 'btrfs' ]; then
     debug 'INFO' 'Using mkfs.btrfs to format root filesystem'
     partprobe "$LOOP"
-    if ! output=$(mkfs.btrfs -f -m single -L "$LABEL" -v "$IMG_DEV_ROOT_PATH" 2>&1 | tee "$TTY_AVAILABILITY" ); then # btrfs does NOT like having the same uuid on 2 filesystems at the same time
+    if ! output=$(mkfs.btrfs -f -m single -L "$LABEL" -v "$IMG_DEV_ROOT_PATH" 2>&1 | tee "$TTY_AVAILABILITY" ); then # btrfs does work with having the same uuid on 2 filesystems at the same time
       echo -e "${Yellow}$output\n${Red}!! MKFS.BTRFS FAILED!!!"
       debug 'BREAK'
-      debug 'ERROR' "MKFS.BTRFS FAILED:\n$output\n------------------------------------------------------------------------------"
+      debug 'ERROR' "MKFS.BTRFS FAILED:\n$output\n-------------------------------------------------------------------------------------"
       exit 1
     fi
     debug 'BREAK'
-    debug 'DEBUG' "Running: mkfs.btrfs -f -m single -L $LABEL -v $IMG_DEV_ROOT_PATH\n$output\n------------------------------------------------------------------------------"
+    debug 'DEBUG' "Running: mkfs.btrfs -f -m single -L $LABEL -v $IMG_DEV_ROOT_PATH\n$output\n-------------------------------------------------------------------------------------"
     $SLEEPING
 
     # Check for temp directory and create if needed
@@ -1475,16 +1437,32 @@ function make_img() {
       debug 'DEBUG' "TMP_DIR=$TMP_DIR"
     fi
 
+    # Mount btrfs filesystem and create volumes
     echo -e "${White}## ${IWhite}Creating btrfs subvolumes..."
     debug 'INFO' 'Creating btrfs subvolumes'
     debug 'DEBUG' "Running: mount -o noatime,compress=zstd $IMG_DEV_ROOT_PATH $TMP_DIR"
     if ! output=$(mount -o noatime,compress=zstd "$IMG_DEV_ROOT_PATH" "$TMP_DIR" 2>&1); then
       echo -e "${Yellow}$output\n${Red}!! ROOT MOUNT FAILED!!!"
       debug 'BREAK'
-      debug 'ERROR' "ROOT MOUNT FAILED:\n$output\n------------------------------------------------------------------------------"
+      debug 'ERROR' "BTRFS FILESYSTEM MOUNT FAILED:\n$output\n-------------------------------------------------------------------------------------"
       exit 1
     fi
     $SLEEPING
+
+    # Overhaul, test this instead:
+#     for subvol in "${LOCAL_SUBVOLUMES[@]}"; do
+#       if [[ "$subvol" == '@'* ]]; then
+#         echo -e "${White}## ${IWhite}Creating subvolume: ${Green}$subvol"
+#         debug 'DEBUG' "Running: btrfs subvolume create ${TMP_DIR}/${subvol}"
+#         if ! output=$(btrfs subvolume create "$TMP_DIR"/"$subvol" 2>&1); then
+#           echo -e "${Yellow}$output\n${Red}!! CREATE SUBVOLUME FAILED!!!"
+#           debug 'BREAK'
+#           debug 'ERROR' "CREATE SUBVOLUME FAILED:\n$output\n-------------------------------------------------------------------------------------"
+#           exit 1
+#         fi
+#       fi
+#       $SLEEPING
+#     done
 
     # Create top subvolumes, ${#LOCAL_SUBVOLUMES[@]} gives count
     for ((i = 0; i < ${#LOCAL_SUBVOLUMES[@]}; i++)); do
@@ -1495,13 +1473,14 @@ function make_img() {
         if ! output=$(btrfs subvolume create "$TMP_DIR"/"$subvol_path" 2>&1); then
           echo -e "${Yellow}$output\n${Red}!! CREATE SUBVOLUME FAILED!!!"
           debug 'BREAK'
-          debug 'ERROR' "CREATE SUBVOLUME FAILED:\n$output\n------------------------------------------------------------------------------"
+          debug 'ERROR' "CREATE SUBVOLUME FAILED:\n$output\n-------------------------------------------------------------------------------------"
           exit 1
         fi
       fi
       $SLEEPING
     done
 
+    # Mount root (@) subvolume
     echo -e "${White}## ${IWhite}Mounting root..."
     debug 'INFO' 'Unmounting btrfs filesystem & mounting root subvolume'
     debug 'DEBUG' "Running: umount $TMP_DIR"
@@ -1514,15 +1493,33 @@ function make_img() {
     if ! output=$(mount -o "${fstab[3]}" "$IMG_DEV_ROOT_PATH" "$TMP_DIR" 2>&1); then
       echo -e "${Yellow}$output\n${Red}!! ROOT SUBVOLUME MOUNT FAILED!!!"
       debug 'BREAK'
-      debug 'ERROR' "ROOT SUBVOLUME MOUNT FAILED:\n$output\n------------------------------------------------------------------------------"
+      debug 'ERROR' "ROOT SUBVOLUME MOUNT FAILED:\n$output\n-------------------------------------------------------------------------------------"
       exit 1
     fi
     $SLEEPING
 
-    # Create nested volumes/snapshots
+    # Create nested volumes
     echo -e "${White}## ${IWhite}Creating nested volumes if existing..."
-    debug 'INFO' 'Creating nested volumes/snapshots'
+    debug 'INFO' 'Creating nested volumes'
     $SLEEPING
+
+    # Overhaul, test this instead:
+#     for subvol in "${LOCAL_SUBVOLUMES[@]}"; do
+#     if [[ "$subvol" != '@'* ]]; then
+#         debug 'DEBUG' "Running: mkdir -p $TMP_DIR/$(dirname $subvol)"
+#         mkdir -p "$TMP_DIR"/$(dirname "$subvol")
+#         echo -e "${White}## ${IWhite}Creating volume: ${Green}$subvol"
+#         debug 'DEBUG' "Running: btrfs subvolume create ${TMP_DIR}/$subvol"
+#         if ! output=$(btrfs subvolume create "$TMP_DIR"/"$subvol" 2>&1); then
+#           echo -e "${Yellow}$output\n${Red}!! CREATE VOLUME FAILED!!!"
+#           debug 'BREAK'
+#           debug 'ERROR' "CREATE VOLUME FAILED:\n$output\n-------------------------------------------------------------------------------------"
+#           exit 1
+#         fi
+#       fi
+#       $SLEEPING
+#     done
+
     for ((i = 0; i < ${#LOCAL_SUBVOLUMES[@]}; i++)); do
       subvol_path="${LOCAL_SUBVOLUMES[i]}"
       if [[ "$subvol_path" != '@'* ]]; then
@@ -1533,20 +1530,41 @@ function make_img() {
         if ! output=$(btrfs subvolume create "$TMP_DIR"/"$subvol_path" 2>&1); then
           echo -e "${Yellow}$output\n${Red}!! CREATE VOLUME FAILED!!!"
           debug 'BREAK'
-          debug 'ERROR' "CREATE VOLUME FAILED:\n$output\n------------------------------------------------------------------------------"
+          debug 'ERROR' "CREATE VOLUME FAILED:\n$output\n-------------------------------------------------------------------------------------"
           exit 1
         fi
       fi
       $SLEEPING
     done
 
+    # Mount volumes from fstab
     echo -e "${White}## ${IWhite}Mounting img btrfs volumes..."
     debug 'INFO' 'Mounting volumes'
     partprobe "$LOOP"
     $SLEEPING
 
+    # Overhaul, test this instead:
+#     for subvol in "${LOCAL_SUBVOLUMES[@]}"; do
+#       # Excluding root (@) subvolume and mounting all else in fstab, nested volumes are not in fstab
+#       if grep -q "$subvol" /etc/fstab && [[ "$subvol" != '@' ]]; then
+#         declare -a fstab=( $(cat /etc/fstab | grep "$subvol") )
+#         debug 'DEBUG' "Running: mkdir -p ${TMP_DIR}${fstab[1]}"
+#         mkdir -p "${TMP_DIR}${fstab[1]}"
+#         echo -e "${White}## ${IWhite}Mounting subvolume: ${Green}$subvol"
+#         debug 'DEBUG' "Running: mount -o ${fstab[3]} $IMG_DEV_ROOT_PATH ${TMP_DIR}${fstab[1]}"
+#         if ! output=$(mount -o "${fstab[3]}" "$IMG_DEV_ROOT_PATH" "${TMP_DIR}${fstab[1]}" 2>&1); then
+#           echo -e "${Yellow}$output\n${Red}!! SUBVOLUME MOUNT FAILED!!!"
+#           debug 'BREAK'
+#           debug 'ERROR' "SUBVOLUME MOUNT FAILED:\n$output\n-------------------------------------------------------------------------------------"
+#           exit 1
+#         fi
+#       fi
+#       $SLEEPING
+#     done
+
     for ((i = 0; i < ${#LOCAL_SUBVOLUMES[@]}; i++)); do
       subvol_path="${LOCAL_SUBVOLUMES[i]}"
+      # Excluding root (@) subvolume and mounting all else in fstab, nested volumes are not in fstab
       if grep -q "$subvol_path" /etc/fstab && [[ "$subvol_path" != '@' ]]; then
         declare -a fstab=( $(cat /etc/fstab | grep "$subvol_path") )
         debug 'DEBUG' "Running: mkdir -p ${TMP_DIR}${fstab[1]}"
@@ -1554,9 +1572,9 @@ function make_img() {
         echo -e "${White}## ${IWhite}Mounting subvolume: ${Green}$subvol_path"
         debug 'DEBUG' "Running: mount -o ${fstab[3]} $IMG_DEV_ROOT_PATH ${TMP_DIR}${fstab[1]}"
         if ! output=$(mount -o "${fstab[3]}" "$IMG_DEV_ROOT_PATH" ${TMP_DIR}${fstab[1]} 2>&1); then
-          echo -e "${Yellow}$output\n${Red}!! VOLUME MOUNT FAILED!!!"
+          echo -e "${Yellow}$output\n${Red}!! SUBVOLUME MOUNT FAILED!!!"
           debug 'BREAK'
-          debug 'ERROR' "VOLUME MOUNT FAILED:\n$output\n------------------------------------------------------------------------------"
+          debug 'ERROR' "SUBVOLUME MOUNT FAILED:\n$output\n-------------------------------------------------------------------------------------"
           exit 1
         fi
       fi
@@ -1569,7 +1587,7 @@ function make_img() {
     if ! output=$(mount "$IMG_DEV_BOOT_PATH" "${TMP_DIR}${BOOT_PATH}" 2>&1); then
       echo -e "${Yellow}$output\n${Red}!! BOOT MOUNT FAILED!!!"
       debug 'BREAK'
-      debug 'ERROR' "BOOT MOUNT FAILED:\n$output\n------------------------------------------------------------------------------"
+      debug 'ERROR' "BOOT MOUNT FAILED:\n$output\n-------------------------------------------------------------------------------------"
       exit 1
     fi
     $SLEEPING
@@ -1580,7 +1598,7 @@ function make_img() {
   debug 'INFO' 'Running function: do_rsync'
   do_rsync
 
-  # Editing fstab and cmdline.txt on img file for f2fs conversion
+  # Edit fstab and cmdline.txt on img file for f2fs conversion
   if [ "$F2FS" = true ]; then
     echo -e "${White}## ${IWhite}Editing img configurations for f2fs..."
     $SLEEPING
@@ -1619,31 +1637,31 @@ return 0
 
 
 # Update existing backup img file
-function do_backup() {
+function update_img() {
 
-  # Making sure img file exists
+  # Make sure img file exists
   if ! [ -f "$IMG_FILE" ]; then
     echo -e "${Red}!! ERROR! ${Green}$IMG_FILE ${Yellow}does not exist!"
     debug 'ERROR' "$IMG_FILE does not exist, exit 1"
     exit 1
   fi
 
-  debug 'INFO' 'Running function: get_dev_variables'
-  # get_btrfs_variables is run within get_dev_variables
-  get_dev_variables
+  debug 'INFO' 'Running function: dev_variables'
+  # btrfs_variabless is run within dev_variables
+  dev_variables
 
   debug 'INFO' 'Running function: do_loop'
   do_loop
 
-  debug 'INFO' 'Running function: get_img_variables'
-  get_img_variables
+  debug 'INFO' 'Running function: img_variables'
+  img_variables
 
-  # Checking if resizing should be performed
+  # Check if resizing should be performed
   if [ "$AUTORESIZE_RUN" = true ]; then
     debug 'DEBUG' "Running: fdisk --bytes -lo device,size "$LOOP" | grep "$IMG_DEV_ROOT_PATH" | awk '{print \$2}'"
     IMG_ROOT_SIZE=$(fdisk --bytes -lo device,size "$LOOP" | grep "$IMG_DEV_ROOT_PATH" | awk '{print $2}' )
     diff=$(( (LOCAL_AUTORESIZE_MIN - IMG_ROOT_SIZE) / 1024 / 1024 ))
-    [[ "$diff" != -* ]] && diff="+${diff}" # add a + in case the value is not negative for formatting reasons
+    [[ "$diff" != '-'* ]] && diff="+${diff}" # add a + in case the value is not negative for formatting reasons
     debug 'DEBUG' "IMG_ROOT_SIZE=$IMG_ROOT_SIZE bytes | LOCAL_AUTORESIZE_MIN=$LOCAL_AUTORESIZE_MIN bytes | diff=${diff}MiB"
 
     if [ "$IMG_ROOT_SIZE" -lt "$LOCAL_AUTORESIZE_MIN" ] && (( LOCAL_AUTORESIZE_MIN - IMG_ROOT_SIZE >= 268435456 )); then # 256MiB in bytes
@@ -1653,13 +1671,14 @@ function do_backup() {
       DIFFERENCE="${diff}MiB, Shrinking img filesystem"
       RESIZE_FUNCTION='shrink'
     else
-      if [ "$diff" != -* ]; then
-        DIFFERENCE="Too small (${diff}MiB), not expanding filesystem (must be >=256MiB)"
+      if [[ "$diff" != '-'* ]]; then
+        DIFFERENCE="Too small (${diff}MiB), not expanding filesystem (must be >=+256MiB)"
         diff_small=true
       else
-        DIFFERENCE="Too small (${diff}MiB), not shrinking filesystem (must be >=512MiB)"
+        DIFFERENCE="Too small (${diff}MiB), not shrinking filesystem (must be >=-512MiB)"
         diff_small=true
       fi
+    debug 'DEBUG' "DIFFERENCE=$DIFFERENCE"
     fi
   # Change TRUNCATE_TOTAL to be based on img file instead of local root if [extra space] is provided
   elif [ "$ADDED_SPACE" -ne 0 ]; then
@@ -1689,13 +1708,14 @@ function do_backup() {
     echo -e "# ${Green}--fix ${IWhite}option selected, rsync will delete files on img before copy ${Purple}$(printf "%+$(( COLS - 68 ))s" '#')"
     debug 'DEBUG' '--fix selected by user, rsync deleting files before copy'
   fi
-  echo -e "${Purple}# --------------------------------------------------------------------------------- #"
+  echo -e "${Purple}# $(printf %$(( COLS - 4 ))s | tr ' ' '-') #"
   echo -e "# ${IWhite}Write to logfile:              ${Green}$DEBUG ${Purple}$(printf "%+$(( COLS - 33 - $(echo ${DEBUG} | wc -m ) ))s" '#')"
   echo -e "# ${IWhite}Zoom speed requested:          ${Green}$ZOOM ${Purple}$(printf "%+$(( COLS - 33 - $(echo ${ZOOM} | wc -m ) ))s" '#')"
   echo -e "# ${IWhite}rsync tty output:              ${Green}$RSYNC_TTY ${Purple}$(printf "%+$(( COLS - 33 - $(echo ${RSYNC_TTY} | wc -m ) ))s" '#')"
   echo -e "# ${IWhite}Autocalculate img root size:   ${Green}$AUTORESIZE_RUN ${Purple}$(printf "%+$(( COLS - 33 - $(echo ${AUTORESIZE_RUN} | wc -m ) ))s" '#')"
   echo -e "# ${IWhite}Autoexpand filesystem at boot: ${Green}$AUTOEXPAND ${Purple}$(printf "%+$(( COLS - 33 - $(echo ${AUTOEXPAND} | wc -m ) ))s" '#')"
   echo -e "# ${IWhite}Use exclude.txt:               ${Green}$EXCLUDE_FILE ${Purple}$(printf "%+$(( COLS - 33 - $(echo ${EXCLUDE_FILE} | wc -m ) ))s" '#')"
+  echo -e "# ${IWhite}Boot partition:                ${Green}$BOOT_PARTITION ${Purple}$(printf "%+$(( COLS - 33 - $(echo ${BOOT_PARTITION} | wc -m ) ))s" '#')"
   print_temp="$(( LOCAL_BOOTSECTOR / 1024 / 1024 ))"
   echo -e "# ${IWhite}Bootsector size:               ${Green}${print_temp}MiB ${Purple}$(printf "%+$(( COLS - 36 - $(echo ${print_temp} | wc -m ) ))s" '#')"
   if [ "$AUTORESIZE_RUN" = true ]; then
@@ -1712,16 +1732,16 @@ function do_backup() {
     fi
   elif [ "$ADDED_SPACE" -ne 0 ]; then
     print_temp="$(( $(df / -k --sync --output=used | tail -1) / 1024 ))"
-    echo -e "# ${IWhite}Estemated root usage:          ${Green}${print_temp}MiB ${Purple}$(printf "%+$(( COLS - 36 - $(echo ${print_temp} | wc -m ) ))s" '#')"
+    echo -e "# ${IWhite}Estimated root usage:          ${Green}${print_temp}MiB ${Purple}$(printf "%+$(( COLS - 36 - $(echo ${print_temp} | wc -m ) ))s" '#')"
+    print_temp="$(( ADDED_SPACE / 1024 / 1024 ))"
+    echo -e "# ${IWhite}Added [extra space]:           ${Green}${print_temp}MiB ${Purple}$(printf "%+$(( COLS - 36 - $(echo ${print_temp} | wc -m ) ))s" '#')"
     print_temp="$(( IMG_SIZE / 1024 / 1024 ))"
     echo -e "# ${IWhite}Old img size:                  ${Green}${print_temp}MiB ${Purple}$(printf "%+$(( COLS - 36 - $(echo ${print_temp} | wc -m ) ))s" '#')"
     print_temp="$(( TRUNCATE_TOTAL / 1024 / 1024 ))"
     echo -e "# ${IWhite}New img size:                  ${Green}${print_temp}MiB ${Purple}$(printf "%+$(( COLS - 36 - $(echo ${print_temp} | wc -m ) ))s" '#')"
-    print_temp="$(( ADDED_SPACE / 1024 / 1024 ))"
-    echo -e "# ${IWhite}Difference:                    ${Green}${print_temp}MiB ${Purple}$(printf "%+$(( COLS - 36 - $(echo ${print_temp} | wc -m ) ))s" '#')"
   else
     print_temp="$(( $(df / -k --sync --output=used | tail -1) / 1024 ))"
-    echo -e "# ${IWhite}Estemated root usage:          ${Green}${print_temp}MiB ${Purple}$(printf "%+$(( COLS - 36 - $(echo ${print_temp} | wc -m ) ))s" '#')"
+    echo -e "# ${IWhite}Estimated root usage:          ${Green}${print_temp}MiB ${Purple}$(printf "%+$(( COLS - 36 - $(echo ${print_temp} | wc -m ) ))s" '#')"
     print_temp="$(( IMG_SIZE / 1024 / 1024 ))"
     echo -e "# ${IWhite}Total img size:                ${Green}${print_temp}MiB ${Purple}$(printf "%+$(( COLS - 36 - $(echo ${print_temp} | wc -m ) ))s" '#')"
   fi
@@ -1739,36 +1759,35 @@ function do_backup() {
   elif [ "$PROMPTS" = true ]; then
     debug 'INFO' 'Do you want to continue? [y/n]'
     while true; do
-      read -n 1 -r -p '## Do you want to continue? [y/n] ' input
+      if [ "$COLORS" = true ]; then
+        read -r -p $'\e[0;37m## \e[0;97mDo you want to continue? \e[0;92m[y/n] \e[0m' input
+      else
+        read -r -p '## Do you want to continue? [y/n] ' input
+      fi
       case $input in
-        [Yy]) echo -e '\n'; break;;
-        [Nn]) echo -e "\n${Red}!! Aborting..."; exit 4;;
-        *) echo -e "\n${Yellow}!! ${Red}ERROR! ${Yellow}Please enter ${Green}'y/Y' ${Yellow}or ${Green}'n/N'${Yellow}"; debug 'WARNING' "ERROR, please enter 'y/Y' or 'n/N'";;
+        [Yy]) break;;
+        [Nn]) echo -e "${Red}!! Aborting..."; exit 4;;
+        *) echo -e "${Yellow}!! ${Red}ERROR! ${Yellow}Please enter ${Green}'y' ${Yellow}or ${Green}'n'${Yellow}"; debug 'WARNING' "ERROR, please enter 'y' or 'n'";;
       esac
     done
     debug 'INFO' 'Y or y pressed to confirm'
     debug 'BREAK'
   fi
 
-  # Resizing if needed
+  # Resize if needed
   if [ "$AUTORESIZE_RUN" = true ]; then
     # Expanding
-    if [ "$RESIZE_FUNCTION" = 'expand' ]; then
-      debug 'INFO' 'Img root partition size is smaller than auto calculated size'
-      debug 'DEBUG' "Difference=$diff MiB"
+    if [ "$RESIZE_FUNCTION" == 'expand' ]; then
       debug 'INFO' "Running function: do_resize 'expand'"
       do_resize 'expand'
 
     # Shrinking
-    elif [ "$RESIZE_FUNCTION" = 'shrink' ]; then
-      debug 'INFO' 'Img root partition size is bigger than auto calculated size'
-      debug 'DEBUG' "diff=${diff}MiB"
+    elif [ "$RESIZE_FUNCTION" == 'shrink' ]; then
       debug 'INFO' 'Running function: do_mount'
       do_mount
       debug 'INFO' 'Backing up files'
       debug 'INFO' 'Running function: do_rsync'
       do_rsync
-      debug 'INFO' 'Shrinking img filesystem'
       debug 'INFO' "Running function: do_resize 'shrink'"
       do_resize 'shrink'
       return 0
@@ -1974,48 +1993,50 @@ return 0
 # Print result
 function print_result() {
 
-  declare -i AFTER_SIZE=$(stat -c %s "$IMG_FILE")
+  AFTER_SIZE=$(stat -c %s "$IMG_FILE")
   AFTER_SIZE=$(( AFTER_SIZE / 1024 / 1024 ))
+  IMG_ROOT_SIZE=$(fdisk --bytes -lo device,size "$LOOP" | grep "$IMG_DEV_ROOT_PATH" | awk '{print $2}' )
 
   echo -e "${White}## ${Green}Backup done."
   echo -e "${Purple}${BREAK}"
-
-  echo -e "## ${IWhite}Backup location: ${Green}${IMG_FILE} ${Purple}$(printf "%+$(( COLS - 20 - $(echo ${IMG_FILE} | wc -m ) ))s" '#')"
-
-  echo -e "## ${IWhite}Write to logfile: ${Green}$DEBUG ${Purple}$(printf "%+$(( COLS - 21 - $(echo ${DEBUG} | wc -m ) ))s" '#')"
-  echo -e "## ${IWhite}Autoexpand filesystem at boot: ${Green}$AUTOEXPAND ${Purple}$(printf "%+$(( COLS - 34 - $(echo ${AUTOEXPAND} | wc -m ) ))s" '#')"
-  echo -e "## ${IWhite}Use exclude.txt: ${Green}$EXCLUDE_FILE ${Purple}$(printf "%+$(( COLS - 20 - $(echo ${EXCLUDE_FILE} | wc -m ) ))s" '#')"
+  echo -e "# ${IWhite}Backup location: ${Green}${IMG_FILE} ${Purple}$(printf "%+$(( COLS - 19 - $(echo ${IMG_FILE} | wc -m ) ))s" '#')"
+  echo -e "# ${IWhite}Write to logfile: ${Green}$DEBUG ${Purple}$(printf "%+$(( COLS - 20 - $(echo ${DEBUG} | wc -m ) ))s" '#')"
+  echo -e "# ${IWhite}Autoexpand filesystem at boot: ${Green}$AUTOEXPAND ${Purple}$(printf "%+$(( COLS - 33 - $(echo ${AUTOEXPAND} | wc -m ) ))s" '#')"
+  echo -e "# ${IWhite}Use exclude.txt: ${Green}$EXCLUDE_FILE ${Purple}$(printf "%+$(( COLS - 19 - $(echo ${EXCLUDE_FILE} | wc -m ) ))s" '#')"
+  echo -e "# ${IWhite}Boot partition: ${Green}$BOOT_PARTITION ${Purple}$(printf "%+$(( COLS - 18 - $(echo ${BOOT_PARTITION} | wc -m ) ))s" '#')"
+  print_temp="$(( LOCAL_BOOTSECTOR / 1024 / 1024 ))"
+  echo -e "# ${IWhite}Bootsector size: ${Green}${print_temp}MiB ${Purple}$(printf "%+$(( COLS - 22 - $(echo ${print_temp} | wc -m ) ))s" '#')"
+  print_temp="$(( $(df / -k --sync --output=used | tail -1) / 1024 ))"
+  echo -e "# ${IWhite}Estimated root usage: ${Green}${print_temp}MiB ${Purple}$(printf "%+$(( COLS - 27 - $(echo ${print_temp} | wc -m ) ))s" '#')"
 
   # New backup
-  if [ "$UPDATE" != true ]; then
+  if [ "$UPDATE" = false ]; then
     if [ "$AUTORESIZE_RUN" = true ]; then
       print_temp="$(( LOCAL_AUTORESIZE_MIN / 1024 / 1024 ))"
-      #echo -e "## ${Green}${IMG_FILE} ${IWhite}is ${Green}${AFTER_SIZE}MiB ${IWhite}with a ${Green}root partition ${IWhite}of ${Green}${print_temp}MiB ${Purple}$(printf "%+$(( COLS - 37 - $(echo ${IMG_FILE} | wc -m ) - $(echo ${AFTER_SIZE} | wc -m ) - $(echo ${print_temp} | wc -m ) ))s" '#')"
-
-      echo -e "## ${IWhite}Backup size: ${Green}${AFTER_SIZE}MiB ${IWhite}with a ${Green}root partition ${IWhite}of ${Green}${print_temp}MiB ${Purple}$(printf "%+$(( COLS - 49 - $(echo ${AFTER_SIZE} | wc -m ) - $(echo ${print_temp} | wc -m ) ))s" '#')"
-
+      echo -e "# ${IWhite}Image size: ${Green}${AFTER_SIZE}MiB ${IWhite}with a ${Green}root partition ${IWhite}of ${Green}${print_temp}MiB ${Purple}$(printf "%+$(( COLS - 45 - $(echo ${AFTER_SIZE} | wc -m ) - $(echo ${print_temp} | wc -m ) ))s" '#')"
       debug 'INFO' "$IMG_FILE is ${AFTER_SIZE}MiB with a root partition of $(( LOCAL_AUTORESIZE_MIN / 1024 / 1024 ))MiB"
     else
       print_temp="$(( ADDED_SPACE / 1024 / 1024 ))"
-      #echo -e "## ${Green}$IMG_FILE ${IWhite}is ${Green}${AFTER_SIZE}MiB ${IWhite}with ${Green}${print_temp}MiB [extra space] ${IWhite}included ${Purple}$(printf "%+$(( COLS - 40 - $(echo ${IMG_FILE} | wc -m ) - $(echo ${AFTER_SIZE} | wc -m ) - $(echo ${print_temp} | wc -m ) ))s" '#')"
-
-      echo -e "## ${IWhite}Backup size: ${Green}${AFTER_SIZE}MiB ${IWhite}with ${Green}${print_temp}MiB [extra space] ${IWhite}included ${Purple}$(printf "%+$(( COLS - 40 - $(echo ${AFTER_SIZE} | wc -m ) - $(echo ${print_temp} | wc -m ) ))s" '#')"
-
+      echo -e "# ${IWhite}Added [extra space]: ${Green}${print_temp}MiB ${Purple}$(printf "%+$(( COLS - 26 - $(echo ${print_temp} | wc -m ) ))s" '#')"
+      print_temp=$(( IMG_ROOT_SIZE / 1024 / 1024 ))
+      echo -e "# ${IWhite}Image size: ${Green}${AFTER_SIZE}MiB ${IWhite}with a ${Green}root partition ${IWhite}of ${Green}${print_temp}MiB ${Purple}$(printf "%+$(( COLS - 45 - $(echo ${AFTER_SIZE} | wc -m ) - $(echo ${print_temp} | wc -m ) ))s" '#')"
       debug 'INFO' "$IMG_FILE is ${AFTER_SIZE}MiB with $(( ADDED_SPACE / 1024 / 1024 ))MiB [extra space] included"
     fi
     debug 'INFO' 'Img file created'
 
   # Updated backup
   else
-    #echo -e "## ${Green}$IMG_FILE ${IWhite}is ${Green}${AFTER_SIZE}MiB ${Purple}$(printf "%+$(( COLS - 9 - $(echo ${IMG_FILE} | wc -m ) - $(echo ${AFTER_SIZE} | wc -m ) ))s" '#')"
-
-    echo -e "## ${IWhite}Backup size: ${Green}${AFTER_SIZE}MiB ${Purple}$(printf "%+$(( COLS - 20 - $(echo ${AFTER_SIZE} | wc -m ) ))s" '#')"
-
+    if [ "$ADDED_SPACE" -ne 0 ]; then
+      print_temp="$(( ADDED_SPACE / 1024 / 1024 ))"
+      echo -e "# ${IWhite}Added [extra space]: ${Green}${print_temp}MiB ${Purple}$(printf "%+$(( COLS - 26 - $(echo ${print_temp} | wc -m ) ))s" '#')"
+    fi
+    print_temp=$(( IMG_ROOT_SIZE / 1024 / 1024 ))
+    echo -e "# ${IWhite}Image size: ${Green}${AFTER_SIZE}MiB ${IWhite}with a ${Green}root partition ${IWhite}of ${Green}${print_temp}MiB ${Purple}$(printf "%+$(( COLS - 45 - $(echo ${AFTER_SIZE} | wc -m ) - $(echo ${print_temp} | wc -m ) ))s" '#')"
     debug 'INFO' "$IMG_FILE is ${AFTER_SIZE}MiB"
     debug 'INFO' 'Img file updated'
   fi
   if [ "$AUTOEXPAND" = true ]; then
-    echo -e "## ${Yellow}Please wait for the system to reboot after restoring an image with autoexpansion ${Purple}$(printf "%+$(( COLS - 84 ))s" '#')"
+    echo -e "# ${Yellow}Please wait for the system to reboot after restoring an image with autoexpansion ${Purple}$(printf "%+$(( COLS - 83 ))s" '#')"
   fi
   echo -e "${Purple}${BREAK}"
   debug 'INFO' 'Backup done'
@@ -2087,23 +2108,34 @@ if [ "$LOOPRUN" = true ] && [ -z "$ADDED_SPACE" ]; then
   debug 'DEBUG' "ADDED_SPACE=$ADDED_SPACE"
 fi
 
+# Requesting user to input [extra space] if new image and not provided
+if [ "$UPDATE" = false ] && [ -z "$ADDED_SPACE" ]; then
+  debug 'INFO' 'New image without -a option and no [extra space] defined by user, requesting user input'
+  echo -e "${White}## ${IWhite}New image requested without ${Yellow}-a ${IWhite}option and no provided ${Yellow}[extra space]"
+  if [ "$COLORS" = true ]; then
+    read -r -p $'\e[0;37m## \e[0;97mPlease input requested \e[0;92m[extra space] in MiB \e[0;97m(0 is valid): ' ADDED_SPACE
+  else
+    read -r -p '## Please input requested [extra space] in MiB (0 is valid): ' ADDED_SPACE
+  fi
+  debug 'USER_INPUT' "User requested ${ADDED_SPACE}MiB as ADDED_SPACE"
+fi
+
 # Regular expression for whole numbers
 RE='^[0-9]+$'
 
 # Validate the added space argument as a whole number
 if ! [[ "$ADDED_SPACE" =~ $RE ]]; then
   debug 'WARNING' 'User defined ADDED_SPACE is not a regualar expression (whole number)'
+  debug 'DEBUG' "ADDED_SPACE=$ADDED_SPACE"
   COUNTER=0
   while ! [[ "$ADDED_SPACE" =~ $RE ]]
   do
     if [ "$COUNTER" -gt 0 ]; then
       echo -e "${Yellow}!! ${Red}ERROR!"
-      debug 'INFO' 'ERROR'
+      debug 'WARNING' 'ERROR, user input ADDED_SPACE not regular expression'
     fi
-    echo -e "${Yellow}!! Added space must be a whole number"
-    echo -e "${Yellow}## How much space in MiB should be added?"
-    debug 'INFO' 'Added space must be a whole number'
-    debug 'INFO' 'How much space in MiB should be added?'
+    echo -e "${Yellow}!! [extra space] space must be a whole number"
+    echo -e "${Yellow}## How much space in MiB should be added to the image? (0 is valid)"
     read ADDED_SPACE
     (( COUNTER++ ))
     #(( COUNTER += 1 ))
@@ -2204,9 +2236,9 @@ if [ "$UPDATE" != true ]; then
   debug 'BREAK'
   make_img
 else
-  debug 'INFO' '-U selected by user, running function: do_backup'
+  debug 'INFO' '-U selected by user, running function: update_img'
   debug 'BREAK'
-  do_backup
+  update_img
 fi
 
 # Check if autoexpansion is requested and run required function

--- a/shrink-backup
+++ b/shrink-backup
@@ -166,9 +166,11 @@ fi
 AUTORESIZE_WARNING=false
 ZOOM=false
 LOOPRUN=false
+CHROOTRUN=false
 RSYNC_DELETE='--delete'
 RSYNC_TTY=true
-F2FS=false
+F2FS_CONVERSION=false
+BTRFS_CONVERSION=false
 #STARTLINE="$0 $*" # will produce double // if script is in $PATH
 STARTLINE="$(dirname $0)/$(basename $0) $*" # will produce absolute path if script is in $PATH
 #STARTLINE="$(realpath $0) $*" # same as bove, but will ALWYAS produce absolute path
@@ -220,33 +222,39 @@ help() {
 ${IWhite}Script for creating an .img file and subsequently keeing it updated (-U), autoexpansion is enabled by default
 Directory where .img file is created is automatically excluded in backup
 ######################################################################################################################
-Usage: ${Green}sudo $(basename "$0") [-Uatyelzh] [--fix] [--loop] [--f2fs] imagefile.img [extra space (MiB)]
-  -U            ${IWhite}Update existing img file (rsync to existing img)
-                  Optional [extra space] extends img root partition
-  ${Green}-a            ${IWhite}Autocalculate root size partition, [extra space] is ignored
-                  When used in combination with -U:
-                  Expand if partition is >=256MiB smaller than autocalculated recommended minimum
-                  Shrink if partition is >=512MiB bigger than autocalculated recommended minimum
-  ${Green}-t            ${IWhite}Use exclude.txt in same folder as script to set excluded directories
-                  One directory per line: "/dir" or "/dir/*" to only exclude contents
-  ${Green}-y            ${IWhite}Disable prompts in script (please use this option with care!)
-  ${Green}-e            ${IWhite}Disable autoexpansion on root filesystem when image is booted
-  ${Green}-l            ${IWhite}Write debug messages to logfile shrink-backup.log located in same directory as script
-  ${Green}-z            ${IWhite}Make script zoom at light-speed, only question prompts might slow it down
-                  Can be combined with -y for UNSAFE ultra-mega-superduper-speed
-  ${Green}-q --quiet    ${IWhite}Do not print rsync copy process
-  ${Green}--no-color    ${IWhite}Run script without color formatted text
-  ${Green}--fix         ${IWhite}Try to fix the img file if -a fails with a "broken pipe" error
-  ${Green}--loop [img]  ${IWhite}Loop img file and exit, works in combination with -l & -z
-                  If optional [extra space] is defined, the img file will be extended with the amount before looping
-                  NOTE that only the file gets truncated, no partitions
-                  Useful if you for example want to manually manage the partitions
-  ${Green}--f2fs        ${IWhite}Convert root filesystem on img from ext4 to f2fs
-                  Only works on new img file, not in combination with -U
-                  Will make backups of fstab & cmdline.txt to: fstab.shrink-backup.bak & cmdline.txt.shrink-backup.bak
-                  Then change ext4 to f2fs in both files and add discard to options on root partition in fstab
-  ${Green}--version     ${IWhite}Print version and exit
-  ${Green}-h --help     ${IWhite}Show this help snippet
+Usage: ${Green}sudo $(basename "$0") [options] imagefile.img [extra space (MiB)]
+  -U             ${IWhite}Update existing img file (rsync to existing img)
+                   Optional [extra space] extends img root partition
+  ${Green}-a             ${IWhite}Autocalculate root size partition, [extra space] is ignored
+                   When used in combination with -U:
+                   Expand if partition is >=256MiB smaller than autocalculated recommended minimum
+                   Shrink if partition is >=512MiB bigger than autocalculated recommended minimum
+  ${Green}-t             ${IWhite}Use exclude.txt in same folder as script to set excluded directories
+                   One directory per line: "/dir" or "/dir/*" to only exclude contents
+  ${Green}-y             ${IWhite}Disable prompts in script (please use this option with care!)
+  ${Green}-e             ${IWhite}Disable autoexpansion on root filesystem when image is booted
+  ${Green}-l             ${IWhite}Write debug messages to logfile shrink-backup.log located in same directory as script
+  ${Green}-z             ${IWhite}Make script zoom at light-speed, only question prompts might slow it down
+                   Can be combined with -y for UNSAFE ultra-mega-superduper-speed
+  ${Green}-q --quiet     ${IWhite}Do not print rsync copy process
+  ${Green}--no-color     ${IWhite}Run script without color formatted text
+  ${Green}--fix          ${IWhite}Try to fix the img file if -a fails with a "broken pipe" error
+  ${Green}--loop [img]   ${IWhite}Loop img file and exit, works in combination with -l & -z
+                   If optional [extra space] is defined, the img file will be extended with the amount before looping
+                   NOTE that only the file gets truncated, no partitions
+                   Useful if you for example want to manually manage the partitions
+  ${Green}--chroot [img] ${IWhite}Loop img file, mount to a temp directory, enter chroot environment and drop to shell
+                   This will let you make changes in a chroot environment directly on the img file
+                   For example update with package manager or rebuild initramfs
+                   The script will keep running in the background
+                   Type 'exit' when done and the script will unmount, remove loop and exit
+                   Uses systemd-nspawn
+  ${Green}--f2fs         ${IWhite}Convert root filesystem on img from ext4 to f2fs
+                   Only works on new img file, not in combination with -U
+                   Will make backups of fstab & cmdline.txt to: fstab.shrink-backup.bak & cmdline.txt.shrink-backup.bak
+                   Then change ext4 to f2fs in both files and add discard to options on root partition in fstab
+  ${Green}--version      ${IWhite}Print version and exit
+  ${Green}-h --help      ${IWhite}Show this help snippet
 ######################################################################################################################
 Examples:
 ${Green}sudo $(basename "$0") -a /path/to/backup.img ${White}(create img, automatically set size)
@@ -264,7 +272,7 @@ EOM
 
 
 # Parse command-line options
-options=$(getopt -o Uatyelzhq --long help,version,quiet,fix,f2fs,no-color,loop: -- "$@")
+options=$(getopt -o Uatyelzhq --long help,version,quiet,fix,f2fs,no-color,loop,chroot: -- "$@")
 [ $? -eq 0 ] || {
     echo -e "${Red}Incorrect options provided"
     help
@@ -283,21 +291,21 @@ while true; do
     -z) ZOOM=true; shift;;
     -q|--quiet) RSYNC_TTY=false; shift;;
     --fix) RSYNC_DELETE='--delete-before'; shift;;
-    --f2fs) F2FS=true; shift;;
+    --f2fs) F2FS_CONVERSION=true; shift;;
     --no-color) unset White IWhite Red Blue Green Yellow Purple NC; COLORS=false; debug 'DEBUG' '--no-color selected by user, unsetting color variables'; shift;;
-    --loop) LOOPRUN=true; IMG_FILE="$2"; shift 2;;
+    --loop) LOOPRUN=true; IMG_FILE="$3"; shift;;
+    --chroot) CHROOTRUN=true; IMG_FILE="$2"; shift;;
     --) break;;
     *) shift;;
   esac
 done
 
-# Process the non-option arguments, checks/fixes if the imagefile comes before the options
-while [ "$#" -gt 0 ];
-do
+# Process non-option arguments
+while [ "$#" -gt 0 ]; do
   if [[ "$1" =~ ^- ]]; then
     shift
   elif [ -n "$IMG_FILE" ]; then
-    ADDED_SPACE="$1"
+    ADDED_SPACE="$2"
     break
   else
     IMG_FILE="$1"
@@ -383,6 +391,159 @@ exit 2
 
 
 
+function chrootrun() {
+
+  check_dependencies
+  do_loop
+
+  # Assumes last partition is root
+  partprobe "$LOOP"
+  sleep 2
+  FSTYPE="$(lsblk -no fstype $LOOP | tail -1)"
+  debug 'DEBUG' "FSTYPE=$FSTYPE"
+  # First index (LSBLK_PARTITIONS[0]) will be the loop itself
+  LSBLK_PARTITIONS=($(lsblk -no path $LOOP))
+  debug 'DEBUG' "LSBLK_PARTITIONS=$(echo ${LSBLK_PARTITIONS[@]})"
+
+  # Check for temp directory and create if needed
+  if ! [ -d "$TMP_DIR" ]; then
+    echo -e "${White}## ${IWhite}Creating temp directory..."
+    $SLEEPING
+    debug 'INFO' 'Creating temp directory'
+    debug 'DEBUG' "Running: mktemp -d -t chroot-XXX"
+    TMP_DIR=$(mktemp -d -t chroot-XXX)
+    debug 'DEBUG' "TMP_DIR=$TMP_DIR"
+  fi
+
+  # ext4 or f2fs
+  if [ "$FSTYPE" == 'ext4' ] || [ "$FSTYPE" == 'f2fs' ]; then
+    # Assumes root is on last partition
+    count=$(( ${#LSBLK_PARTITIONS[@]} - 1 )) # ${#LSBLK_PARTITIONS[@]} gives count
+    echo -e "${White}## ${IWhite}Mounting ${Green}root (/) ${IWhite}partition"
+    $SLEEPING
+    debug 'INFO' 'Mounting root partition'
+    debug 'DEBUG' "Running: mount ${LSBLK_PARTITIONS[$count]} $TMP_DIR"
+    if ! output=$(mount "${LSBLK_PARTITIONS[$count]}" "$TMP_DIR" 2>&1); then
+      echo -e "${Yellow}$output\n${Red}!! ROOT MOUNT FAILED!!!"
+      debug 'BREAK'
+      debug 'ERROR' "ROOT MOUNT FAILED:\n$output\n-------------------------------------------------------------------------------------"
+      exit 3
+    fi
+    # Remount with flags from fstab
+    fstab=($(cat "$TMP_DIR"/etc/fstab | grep ' / '))
+    echo -e "${White}## ${IWhite}Remounting ${Green}root (/) ${IWhite}partition with flags from fstab"
+    $SLEEPING
+    debug 'INFO' 'Remounting root partition with flags from fstab'
+    debug 'DEBUG' "Running: mount -o remount,${fstab[3]} $TMP_DIR"
+    if ! output=$(mount -o remount,${fstab[3]} "$TMP_DIR" 2>&1); then
+      echo -e "${Yellow}$output\n${Red}!! REMOUNTING ROOT PARTITION FAILED!!!"
+      debug 'BREAK'
+      debug 'ERROR' "REMOUNTING ROOT PARTITION FAILED:\n$output\n-------------------------------------------------------------------------------------"
+      exit 3
+    fi
+    # Mount boot if exists
+    if grep -q 'boot' $TMP_DIR/etc/fstab; then
+      (( count -- ))
+      debug 'INFO' 'Boot partition found in fstab, mounting boot partition'
+      fstab=($(cat "$TMP_DIR"/etc/fstab | grep 'boot'))
+      BOOT_PATH="${fstab[1]}" # Used to find mount in cleanup function
+      debug 'DEBUG' "BOOT_PATH=$BOOT_PATH"
+      echo -e "${White}## ${IWhite}Mounting ${Green}${fstab[1]} ${IWhite}from fstab"
+      $SLEEPING
+      debug 'DEBUG' "Running: mount -o ${fstab[3]} ${LSBLK_PARTITIONS[$count]} ${TMP_DIR}${fstab[1]}"
+      if ! output=$(mount -o "${fstab[3]}" "${LSBLK_PARTITIONS[$count]}" "${TMP_DIR}${fstab[1]}" 2>&1); then
+        echo -e "${Yellow}$output\n${Red}!! BOOT MOUNT FAILED!!!"
+        debug 'BREAK'
+        debug 'ERROR' "BOOT MOUNT FAILED:\n$output\n-------------------------------------------------------------------------------------"
+        exit 3
+      fi
+    fi
+
+  # btrfs
+  elif [ "$FSTYPE" == 'btrfs' ]; then
+    # Assumes root subvolume is @ and is on second partition
+    echo -e "${White}## ${IWhite}Mounting ${Green}@ ${IWhite}subvolume"
+    $SLEEPING
+    debug 'INFO' 'Mounting @ subvolume'
+    debug 'DEBUG' "Running: mount -o subvol=@ ${LSBLK_PARTITIONS[2]} $TMP_DIR"
+    if ! output=$(mount -o subvol=@ "${LSBLK_PARTITIONS[2]}" "$TMP_DIR" 2>&1); then
+      echo -e "${Yellow}$output\n${Red}!! ROOT SUBVOLUME (@) MOUNT FAILED!!!"
+      debug 'BREAK'
+      debug 'ERROR' "ROOT SUBVOLUME (@) MOUNT FAILED:\n$output\n-------------------------------------------------------------------------------------"
+      exit 3
+    fi
+    # Remount with flags from fstab
+    fstab=($(cat "$TMP_DIR"/etc/fstab | grep ' / '))
+    echo -e "${White}## ${IWhite}Remounting ${Green}@ ${IWhite}subvolume with flags from fstab"
+    $SLEEPING
+    debug 'INFO' 'Remounting @ with flags from fstab'
+    debug 'DEBUG' "Running: mount -o remount,${fstab[3]} $TMP_DIR"
+    if ! output=$(mount -o remount,${fstab[3]} "$TMP_DIR" 2>&1); then
+      echo -e "${Yellow}$output\n${Red}!! REMOUNTING ROOT SUBVOLUME (@) FAILED!!!"
+      debug 'BREAK'
+      debug 'ERROR' "REMOUNTING ROOT SUBVOLUME (@) FAILED:\n$output\n-------------------------------------------------------------------------------------"
+      exit 3
+    fi
+    # Assumes boot exists and is on first partition
+    fstab=($(cat "$TMP_DIR"/etc/fstab | grep 'boot'))
+    BOOT_PATH="${fstab[1]}" # Used to find mount in cleanup function
+    debug 'INFO' 'Mounting boot partition'
+    debug 'DEBUG' "BOOT_PATH=$BOOT_PATH"
+    echo -e "${White}## ${IWhite}Mounting ${Green}${fstab[1]} ${IWhite}from fstab"
+    $SLEEPING
+    debug 'DEBUG' "Running: mount -o ${fstab[3]} ${LSBLK_PARTITIONS[1]} ${TMP_DIR}${fstab[1]}"
+    if ! output=$(mount -o "${fstab[3]}" "${LSBLK_PARTITIONS[1]}" "${TMP_DIR}${fstab[1]}" 2>&1); then
+      echo -e "${Yellow}$output\n${Red}!! BOOT MOUNT FAILED!!!"
+      debug 'BREAK'
+      debug 'ERROR' "BOOT MOUNT FAILED:\n$output\n-------------------------------------------------------------------------------------"
+      exit 3
+    fi
+    # Filter out @ and subvolumes not in fstab
+    IMG_SUBVOLUMES=($(btrfs subvol list $TMP_DIR | awk '{print $9}'))
+    echo -e "${White}## ${IWhite}Subvolumes found on image ${Green}${IMG_SUBVOLUMES[@]}"
+    echo -e "${White}## ${IWhite}Filtering out subvolumes not present in fstab"
+    $SLEEPING
+    debug 'INFO' 'Filtering out @ and subvolumes not in fstab'
+    debug 'DEBUG' "Subvolumes before filtering: $(echo ${IMG_SUBVOLUMES[@]})"
+    for i in ${!IMG_SUBVOLUMES[@]}; do
+      if ! $(grep -q ${IMG_SUBVOLUMES[i]} $TMP_DIR/etc/fstab) || [ $(echo ${IMG_SUBVOLUMES[i]}) == '@' ]; then
+      unset IMG_SUBVOLUMES[i]
+      fi
+    done
+    echo -e "${White}## ${IWhite}Subvolumes to mount: ${Green}${IMG_SUBVOLUMES[@]}"
+    $SLEEPING
+    debug 'DEBUG' "Subvolumes after filtering: ${IMG_SUBVOLUMES[@]}"
+    # Mount remaining subvolumes
+    debug 'INFO' 'Mounting remaining subvolumes'
+    for subvol in ${IMG_SUBVOLUMES[@]}; do
+      fstab=($(cat "$TMP_DIR"/etc/fstab | grep "$subvol"))
+      echo -e "${White}## ${IWhite}Mounting ${Green}${fstab[1]} ${IWhite}from fstab"
+      $SLEEPING
+      debug 'DEBUG' "Running: mount -o ${fstab[3]} ${LSBLK_PARTITIONS[2]} ${TMP_DIR}${fstab[1]}"
+      if ! output=$(mount -o "${fstab[3]}" "${LSBLK_PARTITIONS[2]}" "${TMP_DIR}${fstab[1]}" 2>&1); then
+        echo -e "${Yellow}$output\n${Red}!! SUBVOLUME MOUNT FAILED!!!"
+        debug 'BREAK'
+        debug 'ERROR' "SUBVOLUME MOUNT FAILED:\n$output\n-------------------------------------------------------------------------------------"
+        exit 3
+      fi
+    done
+  fi
+
+  # Enter chroot environment
+  echo -e "${White}## ${IWhite}Running systemd-nspawn, type ${Green}exit ${IWhite}when done to exit chroot environment"
+  echo -e "${White}## ${Yellow}YOU ARE RUNNING AS ROOT!!!${NC}"
+  if systemctl is-active -q systemctl-resolved.service; then
+    debug 'DEBUG' "Running: systemd-nspawn --resolv-conf=replace-stub -D $TMP_DIR bin/bash"
+    systemd-nspawn --resolv-conf=replace-stub -D "$TMP_DIR" bin/bash
+  else
+    debug 'DEBUG' "Running: systemd-nspawn --resolv-conf=copy-host -D $TMP_DIR bin/bash"
+    systemd-nspawn --resolv-conf=copy-host -D "$TMP_DIR" bin/bash
+  fi
+exit 0
+}
+
+
+
 # Gather device information
 function dev_variables() {
 
@@ -463,6 +624,11 @@ function dev_variables() {
   if [ "$AUTORESIZE_RUN" = true ]; then
     debug 'INFO' 'Setting TOTAL (space needed for files on root) to autocalculated size'
     TOTAL=$LOCAL_AUTORESIZE_MIN # bytes
+    # Add 512MiB if f2fs conversion
+    if [ "$F2FS_CONVERSION" = true ]; then
+      debug 'INFO' 'Adding 512MiB because of f2fs conversion'
+      TOTAL=$(( $TOTAL + 536870912 ))
+    fi
   else
     debug 'INFO' 'Calculating TOTAL (space needed for files on root) by adding LOCAL_USED_SPACE and ADDED_SPACE'
     debug 'DEBUG' "LOCAL_USED_SPACE=${LOCAL_USED_SPACE} bytes | ADDED_SPACE=${ADDED_SPACE} bytes"
@@ -601,34 +767,34 @@ function img_variables() {
 
   # Check for btrfs subvolumes on img
   # None of this is needed unless creation of new voumes during update will be implemented
-  if [ "$FSTYPE" = 'btrfs' ] && [ "$UPDATE" = true ]; then
-    # Check for temp directory and create if needed
-    if ! [ -d "$TMP_DIR" ]; then
-      echo -e "${White}## ${IWhite}Creating temp directory..."
-      $SLEEPING
-      debug 'INFO' 'Creating temp directory'
-      debug 'DEBUG' "Running: mktemp -d -t backup-XXX"
-      TMP_DIR=$(mktemp -d -t backup-XXX)
-      debug 'DEBUG' "TMP_DIR=$TMP_DIR"
-    fi
-    $SLEEPING
-    partprobe "$LOOP"
-    declare -a fstab=( $(cat /etc/fstab | grep ' / ') )
-    debug 'INFO' 'Mounting btrfs filesystem to find subvolumes'
-    debug 'DEBUG' "Running: mount -o ${fstab[3]} $IMG_DEV_ROOT_PATH $TMP_DIR"
-    if ! output=$(mount -o "${fstab[3]}" "$IMG_DEV_ROOT_PATH" "$TMP_DIR" 2>&1); then
-      echo -e "${Yellow}$output\n${Red}!! ROOT MOUNT FAILED!!!"
-      debug 'BREAK'
-      debug 'ERROR' "ROOT MOUNT FAILED:\n$output\n-------------------------------------------------------------------------------------"
-      exit 3
-    fi
-    $SLEEPING
-    debug 'DEBUG' "Running: btrfs subvolume list $TMP_DIR | awk '{print \$9}'"
-    declare -a IMG_SUBVOLUMES=( $(btrfs subvolume list "$TMP_DIR" | awk '{print $9}') )
-    debug 'DEBUG' "IMG_SUBVOLUMES=$(echo ${IMG_SUBVOLUMES[@]})"
-    debug 'DEBUG' "Running: umount $TMP_DIR"
-    umount "$TMP_DIR"
-  fi
+#   if [ "$FSTYPE" == 'btrfs' ] && [ "$UPDATE" = true ]; then
+#     # Check for temp directory and create if needed
+#     if ! [ -d "$TMP_DIR" ]; then
+#       echo -e "${White}## ${IWhite}Creating temp directory..."
+#       $SLEEPING
+#       debug 'INFO' 'Creating temp directory'
+#       debug 'DEBUG' "Running: mktemp -d -t backup-XXX"
+#       TMP_DIR=$(mktemp -d -t backup-XXX)
+#       debug 'DEBUG' "TMP_DIR=$TMP_DIR"
+#     fi
+#     $SLEEPING
+#     partprobe "$LOOP"
+#     fstab=($(cat /etc/fstab | grep ' / '))
+#     debug 'INFO' 'Mounting btrfs filesystem to find subvolumes'
+#     debug 'DEBUG' "Running: mount -o ${fstab[3]} $IMG_DEV_ROOT_PATH $TMP_DIR"
+#     if ! output=$(mount -o "${fstab[3]}" "$IMG_DEV_ROOT_PATH" "$TMP_DIR" 2>&1); then
+#       echo -e "${Yellow}$output\n${Red}!! ROOT MOUNT FAILED!!!"
+#       debug 'BREAK'
+#       debug 'ERROR' "ROOT MOUNT FAILED:\n$output\n-------------------------------------------------------------------------------------"
+#       exit 3
+#     fi
+#     $SLEEPING
+#     debug 'DEBUG' "Running: btrfs subvolume list $TMP_DIR | awk '{print \$9}'"
+#     declare -a IMG_SUBVOLUMES=( $(btrfs subvolume list "$TMP_DIR" | awk '{print $9}') )
+#     debug 'DEBUG' "IMG_SUBVOLUMES=$(echo ${IMG_SUBVOLUMES[@]})"
+#     debug 'DEBUG' "Running: umount $TMP_DIR"
+#     umount "$TMP_DIR"
+#   fi
 return 0
 }
 
@@ -638,7 +804,7 @@ return 0
 function check_dependencies() {
 
   # GPT
-  if [ $PARTITION_TABLE == 'gpt' ]; then
+  if [ "$PARTITION_TABLE" == 'gpt' ]; then
     echo -e "${White}## ${Green}GPT partition table detected, ${Yellow}sgdisk needed, ${IWhite}checking for application..."
     $SLEEPING
     if ! command -v sgdisk > /dev/null 2>&1; then
@@ -650,11 +816,10 @@ function check_dependencies() {
         echo -e "${White}## ${Green}apt found, ${IWhite}trying to install gdisk..."
         # Confirm with user input
         if [ "$PROMPTS" = true ]; then
-          echo -e "${Purple}${BREAK}${IWhite}"
           debug 'INFO' 'Do you want to use apt to install gdisk? (will upgrade system first) [y/n]'
           while true; do
             if [ "$COLORS" = true ]; then
-              read -r -p $'\e[0;37m## \e[0;97mDo you want to use apt to install gdisk? (will upgrade system first) \e[0;92m[y/n] \e[0m' input
+              read -r -p $'\e[0;37m## \e[0;93mDo you want to use apt to install gdisk? \e[0;97m(will upgrade system first) \e[0;92m[y/n] \e[0m' input
             else
               read -r -p '## Do you want to use apt to install gdisk? (will upgrade system first) [y/n] ' input
             fi
@@ -678,11 +843,10 @@ function check_dependencies() {
         echo -e "${White}## ${Green}pacman found, ${IWhite}trying to install gdisk..."
         # Confirm with user input
         if [ "$PROMPTS" = true ]; then
-          echo -e "${Purple}${BREAK}${IWhite}"
           debug 'INFO' 'Do you want to use pacman to install gptfdisk? (will run pacman -Syu first) [y/n]'
           while true; do
             if [ "$COLORS" = true ]; then
-              read -r -p $'\e[0;37m## \e[0;97mDo you want to use pacman to install gptfdisk? (will run pacman -Syu first) \e[0;92m[y/n] \e[0m' input
+              read -r -p $'\e[0;37m## \e[0;93mDo you want to use pacman to install gptfdisk? \e[0;97m(will run pacman -Syu first) \e[0;92m[y/n] \e[0m' input
             else
               read -r -p '## Do you want to use pacman to install gptfdisk? (will run pacman -Syu first) [y/n] ' input
             fi
@@ -721,7 +885,7 @@ function check_dependencies() {
   fi
 
   # f2fs conversion
-  if [ "$f2fs" = true ]; then
+  if [ "$F2FS_CONVERSION" = true ]; then
     echo -e "${White}## ${Green}--f2fs option selected, mkfs.f2fs is needed, ${IWhite}checking for application..."
     $SLEEPING
     if ! command -v mkfs.f2fs > /dev/null 2>&1; then
@@ -733,11 +897,10 @@ function check_dependencies() {
         echo -e "${White}## ${Green}apt found, ${IWhite}trying to install f2fs-tools..."
         # Confirm with user input
         if [ "$PROMPTS" = true ]; then
-          echo -e "${Purple}${BREAK}${IWhite}"
           debug 'INFO' 'Do you want to use apt to install f2fs-tools? (will upgrade system first) [y/n]'
           while true; do
             if [ "$COLORS" = true ]; then
-              read -r -p $'\e[0;37m## \e[0;97mDo you want to use apt to install f2fs-tools? (will upgrade system first) \e[0;92m[y/n] \e[0m' input
+              read -r -p $'\e[0;37m## \e[0;93mDo you want to use apt to install f2fs-tools? \e[0;97m(will upgrade system first) \e[0;92m[y/n] \e[0m' input
             else
               read -r -p '## Do you want to use apt to install f2fs-tools? (will upgrade system first) [y/n] ' input
             fi
@@ -770,12 +933,60 @@ function check_dependencies() {
       debug 'INFO' 'mkfs.f2fs is available on system'
       $SLEEPING
     fi
+  fi
 
   # btrfs conversion
-  elif [ "$btrfs" = true ]; then
+  if [ "$BTRFS_CONVERSION" = true ]; then
     echo 'btrfs'
   fi
-return
+
+  # --chroot selected
+  if [ "$CHROOTRUN" = true ]; then
+    echo -e "${White}## ${Green}--chrootrun ${IWhite}selected, ${Yellow}systemd-nspawn needed, ${IWhite}checking for application..."
+    $SLEEPING
+    if ! command -v systemd-nspawn > /dev/null 2>&1; then
+      echo -e "${Yellow}!! systemd-nspawn is NOT installed..."
+      debug 'INFO' 'systemd-nspawn not available on system'
+
+      # Only needed on debian based systems, on arch systemd-nspawn is in systemd package
+      if command -v apt > /dev/null 2>&1; then
+        echo -e "${White}## ${Green}apt found, ${IWhite}trying to install systemd-container..."
+        # Confirm with user input
+        if [ "$PROMPTS" = true ]; then
+          debug 'INFO' 'Do you want to use apt to install systemd-container? (will upgrade system first) [y/n]'
+          while true; do
+            if [ "$COLORS" = true ]; then
+              read -r -p $'\e[0;37m## \e[0;93mDo you want to use apt to install systemd-container? \e[0;97m(will upgrade system first) \e[0;92m[y/n] \e[0m' input
+            else
+              read -r -p '## Do you want to use apt to install systemd-container? (will upgrade system first) [y/n] ' input
+            fi
+            case $input in
+              [Yy]) break;;
+              [Nn]) echo -e "${Red}!! Aborting..."; exit 4;;
+              *) echo -e "${Yellow}!! ${Red}ERROR! ${Yellow}Please enter ${Green}'y' ${Yellow}or ${Green}'n'${Yellow}"; debug 'WARNING' "ERROR, please enter 'y' or 'n'";;
+            esac
+          done
+          debug 'INFO' 'Y or y pressed to confirm'
+          debug 'BREAK'
+          debug 'DEBUG' 'Running: apt update -y && apt upgrade -y && apt install systemd-container -y'
+          apt update -y && apt upgrade -y && apt install systemd-container -y
+        else
+          debug 'DEBUG' 'Running: apt update -y && apt upgrade -y && apt install systemd-container -y'
+          apt update -y && apt upgrade -y && apt install systemd-container -y
+        fi
+        echo -e "${White}## ${Green}systemd-container installed successfully, ${IWhite}resuming..."
+        debug 'INFO' 'systemd-container installed successfully'
+        $SLEEPING
+      fi
+
+    # systemd-nspawn already installed
+    else
+      echo -e "${White}## ${Green}systemd-nspawn is available, ${IWhite}resuming..."
+      debug 'INFO' 'systemd-nspawn is available on system'
+      $SLEEPING
+    fi
+  fi
+return 0
 }
 
 
@@ -819,7 +1030,7 @@ function do_mount() {
   partprobe "$LOOP"
 
   # ext4 & f2fs
-  if [ "$FSTYPE" == 'ext4' ] || [ "$FSTYPE" == 'f2fs' ] || [ "$F2FS" = true ]; then
+  if [ "$FSTYPE" == 'ext4' ] || [ "$FSTYPE" == 'f2fs' ] || [ "$F2FS_CONVERSION" = true ]; then
     echo -e "${White}## ${IWhite}Mounting img root partition..."
     $SLEEPING
     debug 'INFO' 'Mounting root partition from loop'
@@ -1169,7 +1380,7 @@ function do_conversion() {
   if [ "$*" == 'create_partition' ]; then
 
     # f2fs
-    if [ "$F2FS" = true ]; then
+    if [ "$F2FS_CONVERSION" = true ]; then
       debug 'INFO' '--f2fs selected by user, creating f2fs partition on img file'
       debug 'DEBUG' "Running: parted -s -a none $LOOP unit B mkpart primary f2fs $LOCAL_ROOT_START 100%"
       if ! output=$(parted -s -a none "$LOOP" unit B mkpart primary f2fs "$LOCAL_ROOT_START" 100% 2>&1); then
@@ -1184,7 +1395,7 @@ function do_conversion() {
   elif [ "$*" == 'format_filesystem' ]; then
 
     # f2fs
-    if [ "$F2FS" = true ]; then
+    if [ "$F2FS_CONVERSION" = true ]; then
       debug 'INFO' "Using mkfs.f2fs to format root filesystem"
       if ! output=$(mkfs.f2fs -f -U "$UUID" -l "$LABEL" "$IMG_DEV_ROOT_PATH" 2>&1 | tee "$TTY_AVAILABILITY" ); then
         echo -e "${Yellow}$output\n${Red}!! MKFS.F2FS FAILED!!!"
@@ -1204,7 +1415,7 @@ function do_conversion() {
   elif [ "$*" == 'edit_configs' ]; then
 
     # f2fs
-    if [ "$F2FS" = true ]; then
+    if [ "$F2FS_CONVERSION" = true ]; then
       echo -e "${White}## ${IWhite}Editing img configurations for f2fs..."
       $SLEEPING
       echo -e "${White}## ${IWhite}Backups will be created: ${Green}/etc/fstab.shrink-backup.bak ${IWhite}& ${Green}${BOOT_PATH}/cmdline.txt.shrink-backup.bak"
@@ -1256,7 +1467,7 @@ function make_img() {
     echo -e "${Purple}# ${IWhite}btrfs volumes: ${Green}${LOCAL_SUBVOLUMES[@]} ${Purple}$(printf "%+$(( COLS - 17 - $(echo ${LOCAL_SUBVOLUMES[@]} | wc -m ) ))s" '#')"
   elif [ "$FSTYPE" == 'f2fs' ]; then
     echo -e "# ${Yellow}Autoexpand filesystem at boot not available for ${Green}f2fs ${Purple}$(printf "%+$(( COLS - 54 ))s" '#')"
-  elif [ "$F2FS" = true ]; then
+  elif [ "$F2FS_CONVERSION" = true ]; then
     echo -e "# ${Yellow}Converting filesystem into ${Green}f2fs ${Yellow}on img file ${Purple}$(printf "%+$(( COLS - 46 ))s" '#')"
     echo -e "# ${Yellow}Autoexpand filesystem at boot not available for ${Green}f2fs ${Purple}$(printf "%+$(( COLS - 55 ))s" '#')"
   fi
@@ -1292,7 +1503,7 @@ function make_img() {
       echo -e "! ${IWhite}Requested root size:            ${Yellow}${print_temp}MiB $(printf "%+$(( COLS - 37 - $(echo ${print_temp} | wc -m ) ))s" '!')"
     fi
   fi
-  if [ "$F2FS" = true ]; then
+  if [ "$F2FS_CONVERSION" = true ]; then
     echo -e "${Yellow}# $(printf %$(( COLS - 4 ))s | tr ' ' '-') #"
     echo -e "! WARNING!!! --f2fs option selected. f2fs filesystem will be created on img file $(printf "%+$(( COLS - 81 ))s" '!')"
     echo -e "! This option is only for CONVERTING existing filesystem into f2fs on img file $(printf "%+$(( COLS - 79 ))s" '!')"
@@ -1399,10 +1610,6 @@ function make_img() {
   debug 'INFO' 'Running function: img_variables'
   img_variables
 
-  # Check dependencies
-  debug 'INFO' 'Running function: check_dependencies'
-  check_dependencies
-
   # Remove partition
   echo -e "${White}## ${IWhite}Removing root partition..."
   $SLEEPING
@@ -1446,7 +1653,7 @@ function make_img() {
   debug 'INFO' 'Using parted to recreate root partition'
 
   # Converting
-  if [ "$F2FS" = true ]; then
+  if [ "$F2FS_CONVERSION" = true ]; then
     debug 'INFO' "Running function: do_conversion 'create_partition'"
     do_conversion 'create_partition'
 
@@ -1483,7 +1690,7 @@ function make_img() {
   debug 'DEBUG' "LABEL=$LABEL | UUID=$UUID"
 
   # Converting
-  if [ "$F2FS" = true ]; then
+  if [ "$F2FS_CONVERSION" = true ]; then
     debug 'INFO' "Running function: do_conversion 'format_filesystem'"
     do_conversion 'format_filesystem'
 
@@ -1549,17 +1756,17 @@ function make_img() {
 
     # Mount btrfs filesystem and create volumes
     echo -e "${White}## ${IWhite}Creating btrfs subvolumes..."
-    debug 'INFO' 'Creating btrfs subvolumes'
+    debug 'INFO' 'Mounting btrfs filesystem and creating btrfs subvolumes'
     debug 'DEBUG' "Running: mount -o noatime,compress=zstd $IMG_DEV_ROOT_PATH $TMP_DIR"
     if ! output=$(mount -o noatime,compress=zstd "$IMG_DEV_ROOT_PATH" "$TMP_DIR" 2>&1); then
-      echo -e "${Yellow}$output\n${Red}!! ROOT MOUNT FAILED!!!"
+      echo -e "${Yellow}$output\n${Red}!! BTRFS FILESYSTEM MOUNT FAILED!!!"
       debug 'BREAK'
       debug 'ERROR' "BTRFS FILESYSTEM MOUNT FAILED:\n$output\n-------------------------------------------------------------------------------------"
       exit 3
     fi
     $SLEEPING
 
-    # Create top level subvolumes
+    # Create top level subvolumes, assumes subvols starting with @ are level 5 volumes
     for subvol in "${LOCAL_SUBVOLUMES[@]}"; do
       if [[ "$subvol" == '@'* ]]; then
         echo -e "${White}## ${IWhite}Creating subvolume: ${Green}$subvol"
@@ -1585,9 +1792,9 @@ function make_img() {
     declare -a fstab=( $(cat /etc/fstab | grep ' / ') )
     debug 'DEBUG' "Running: mount -o ${fstab[3]} $IMG_DEV_ROOT_PATH $TMP_DIR"
     if ! output=$(mount -o "${fstab[3]}" "$IMG_DEV_ROOT_PATH" "$TMP_DIR" 2>&1); then
-      echo -e "${Yellow}$output\n${Red}!! ROOT SUBVOLUME MOUNT FAILED!!!"
+      echo -e "${Yellow}$output\n${Red}!! ROOT SUBVOLUME (@) MOUNT FAILED!!!"
       debug 'BREAK'
-      debug 'ERROR' "ROOT SUBVOLUME MOUNT FAILED:\n$output\n-------------------------------------------------------------------------------------"
+      debug 'ERROR' "ROOT SUBVOLUME (@) MOUNT FAILED:\n$output\n-------------------------------------------------------------------------------------"
       exit 3
     fi
     $SLEEPING
@@ -1655,13 +1862,13 @@ function make_img() {
   do_rsync
 
   # Edit config files for conversion
-  if [ "$F2FS" = true ]; then
+  if [ "$F2FS_CONVERSION" = true ]; then
     debug 'INFO' "Running function: do_conversion 'edit_configs'"
     do_conversion 'edit_configs'
   fi
 
   # Final check of created img file
-  if [ "$FSTYPE" == 'ext4' ] && [ "$F2FS" = false ]; then
+  if [ "$FSTYPE" == 'ext4' ] && [ "$F2FS_CONVERSION" = false ]; then
     debug 'INFO' "Running function: do_e2fsck 'final'"
     do_e2fsck 'final'
   fi
@@ -2044,21 +2251,22 @@ function print_result() {
 
   # New backup
   if [ "$UPDATE" = false ]; then
+    debug 'INFO' 'Img file created'
     if [ "$AUTORESIZE_RUN" = true ]; then
       print_temp="$(( LOCAL_AUTORESIZE_MIN / 1024 / 1024 ))"
       echo -e "# ${IWhite}Image size: ${Green}${AFTER_SIZE}MiB ${IWhite}with a ${Green}root partition ${IWhite}of ${Green}${print_temp}MiB ${Purple}$(printf "%+$(( COLS - 45 - $(echo ${AFTER_SIZE} | wc -m ) - $(echo ${print_temp} | wc -m ) ))s" '#')"
-      debug 'INFO' "$IMG_FILE is ${AFTER_SIZE}MiB with a root partition of $(( LOCAL_AUTORESIZE_MIN / 1024 / 1024 ))MiB"
+      debug 'DEBUG' "$IMG_FILE is ${AFTER_SIZE}MiB with a root partition of $(( LOCAL_AUTORESIZE_MIN / 1024 / 1024 ))MiB"
     else
       print_temp="$(( ADDED_SPACE / 1024 / 1024 ))"
       echo -e "# ${IWhite}Added [extra space]: ${Green}${print_temp}MiB ${Purple}$(printf "%+$(( COLS - 26 - $(echo ${print_temp} | wc -m ) ))s" '#')"
       print_temp=$(( IMG_ROOT_SIZE / 1024 / 1024 ))
       echo -e "# ${IWhite}Image size: ${Green}${AFTER_SIZE}MiB ${IWhite}with a ${Green}root partition ${IWhite}of ${Green}${print_temp}MiB ${Purple}$(printf "%+$(( COLS - 45 - $(echo ${AFTER_SIZE} | wc -m ) - $(echo ${print_temp} | wc -m ) ))s" '#')"
-      debug 'INFO' "$IMG_FILE is ${AFTER_SIZE}MiB with $(( ADDED_SPACE / 1024 / 1024 ))MiB [extra space] included"
+      debug 'DEBUG' "$IMG_FILE is ${AFTER_SIZE}MiB with a root partition of ${print_temp}MiB including $(( ADDED_SPACE / 1024 / 1024 ))MiB [extra space]"
     fi
-    debug 'INFO' 'Img file created'
 
   # Updated backup
   else
+    debug 'INFO' 'Img file updated'
     if [ "$ADDED_SPACE" -ne 0 ]; then
       print_temp="$(( ADDED_SPACE / 1024 / 1024 ))"
       echo -e "# ${IWhite}Added [extra space]: ${Green}${print_temp}MiB ${Purple}$(printf "%+$(( COLS - 26 - $(echo ${print_temp} | wc -m ) ))s" '#')"
@@ -2066,7 +2274,6 @@ function print_result() {
     print_temp=$(( IMG_ROOT_SIZE / 1024 / 1024 ))
     echo -e "# ${IWhite}Image size: ${Green}${AFTER_SIZE}MiB ${IWhite}with a ${Green}root partition ${IWhite}of ${Green}${print_temp}MiB ${Purple}$(printf "%+$(( COLS - 45 - $(echo ${AFTER_SIZE} | wc -m ) - $(echo ${print_temp} | wc -m ) ))s" '#')"
     debug 'INFO' "$IMG_FILE is ${AFTER_SIZE}MiB"
-    debug 'INFO' 'Img file updated'
   fi
   if [ "$AUTOEXPAND" = true ]; then
     echo -e "# ${Yellow}Please wait for the system to reboot after restoring an image with autoexpansion ${Purple}$(printf "%+$(( COLS - 83 ))s" '#')"
@@ -2138,6 +2345,12 @@ if [ "$LOOPRUN" = true ] && [ -z "$ADDED_SPACE" ]; then
   debug 'INFO' '--loop selected and [extra space] not provided by user, setting ADDED_SPACE to 0 (non-zero value)'
 fi
 
+# Setting ADDED_SPACE to 0 if --chroot is selected
+if [ "$CHROOTRUN" = true ]; then
+  ADDED_SPACE=0
+  debug 'INFO' '--chroot selected, setting ADDED_SPACE to 0 (non-zero value)'
+fi
+
 # Requesting user to input [extra space] if not provided while making new image
 if [ "$UPDATE" = false ] && [ -z "$ADDED_SPACE" ]; then
   debug 'INFO' 'New image without -a option and no [extra space] defined by user, requesting user input'
@@ -2176,8 +2389,14 @@ fi
 
 # If --loop is requested, execute looprun function. Will exit script within the function
 if [ "$LOOPRUN" = true ]; then
-  debug 'INFO' '--loop selected by user, running function: looprun'
+  debug 'INFO' 'Running function: looprun'
   looprun
+fi
+
+# If --chroot is requested, execute chrootrun function. Will exit script within the function
+if [ "$CHROOTRUN" = true ]; then
+  debug 'INFO' 'Running function: chrootrun'
+  chrootrun
 fi
 
 echo -e "${White}## ${IWhite}Scanning filesystem and calculating..."
@@ -2204,13 +2423,13 @@ debug 'DEBUG' "LOCAL_DEV_PTUUID=$LOCAL_DEV_PTUUID | LOCAL_DEV_PATH=$LOCAL_DEV_PA
 PARTITION_TABLE=$(parted "$LOCAL_DEV_PATH" print | grep -i 'Partition Table' | awk '{print $3}')
 #PARTITION_TABLE=$(blkid "$LOCAL_DEV_PATH" | sed -n 's|^.*PTTYPE="\(\S\+\)".*|\1|p')
 
-if [ "$FSTYPE" == 'f2fs' ] || [ "$F2FS" = true ]; then
-  if [ "$FSTYPE" == 'f2fs' ] && [ "$F2FS" = true ]; then
+if [ "$FSTYPE" == 'f2fs' ] || [ "$F2FS_CONVERSION" = true ]; then
+  if [ "$FSTYPE" == 'f2fs' ] && [ "$F2FS_CONVERSION" = true ]; then
     echo -e "${Red}!! ERROR! ${Green}--f2fs ${Yellow}selected with existing ${Green}f2fs filesystem${Yellow}, conversion not needed"
     echo -e "${Red}!! Run script without ${Green}--f2fs"
     debug 'ERROR' '--f2fs selected with existing f2fs filesystem, conversion not needed, exit 1'
     exit 1
-  elif [ "$F2FS" = true ] && [ "$UPDATE" = true ]; then
+  elif [ "$F2FS_CONVERSION" = true ] && [ "$UPDATE" = true ]; then
     echo -e "${Red}!! ERROR! ${Green}--f2fs ${Yellow}selected in combination with ${Green}-U${Yellow}, conversion not possible"
     echo -e "${Red}!! ${Yellow}Create new img to enable ${Green}f2fs conversion"
     debug 'ERROR' '--f2fs selected in combination with -U, operation not supported, exit 1'
@@ -2272,7 +2491,7 @@ if [ "$DEBUG" = true ]; then
   debug 'DEBUG' "EXCLUDE_FILE=$EXCLUDE_FILE"
   debug 'DEBUG' "AUTOEXPAND=$AUTOEXPAND"
   debug 'DEBUG' "RSYNC_DELETE=$RSYNC_DELETE"
-  debug 'DEBUG' "F2FS=$F2FS"
+  debug 'DEBUG' "F2FS_CONVERSION=$F2FS_CONVERSION"
   debug 'DEBUG' "TTY_AVAILABILITY=$TTY_AVAILABILITY"
   debug 'DEBUG' "ADDED_SPACE=$ADDED_SPACE"
   debug 'BREAK'
@@ -2291,6 +2510,11 @@ else
   debug 'INFO' '-f NOT selected by user, using default exclude directories'
 fi
 
+# Check dependencies
+debug 'INFO' 'Running function: check_dependencies'
+check_dependencies
+
+# Create or update image
 if [ "$UPDATE" != true ]; then
   debug 'INFO' 'Running function: make_img'
   debug 'BREAK'

--- a/shrink-backup
+++ b/shrink-backup
@@ -1309,7 +1309,7 @@ function do_e2fsck() {
     $SLEEPING
 
     # Remounting if autoexpansion is requested
-    if [ "$AUTOEXPAND" = true ] && [ "$OS" != 'unknown' ]; then
+    if [ "$AUTOEXPAND" = true ] && [ "$OS" != 'unknown' ] || [ "$AUTOEXPAND" = false ] && [ "$OS" == 'ubuntu' ]; then
       echo -e "${White}## ${IWhite}Remounting for autoexpansion..."
       debug 'INFO' 'Remounting for autoexpansion function'
       debug 'INFO' 'Running function: do_mount'
@@ -1619,6 +1619,9 @@ function make_img() {
   echo -e "# ${IWhite}A backup will be created at: ${Purple}$(printf "%+$(( COLS - 31 ))s" '#')"
   echo -e "# ${Green}$IMG_FILE ${Purple}$(printf "%+$(( COLS - 2 - $(echo ${IMG_FILE} | wc -m ) ))s" '#')"
   echo -e "# ${Green}$FSTYPE ${IWhite}filesystem detected on root ${Purple}$(printf "%+$(( COLS - 30 - $(echo ${FSTYPE} | wc -m ) ))s" '#')"
+  if [ "$RSYNC_DELETE" != '--delete' ]; then
+    echo -e "# ${Green}--fix ${IWhite}option selected, ${Green}rsync using --fsync option${Purple}$(printf "%+$(( COLS - 51 ))s" '#')"
+  fi
   if [ "$FSTYPE" == 'btrfs' ]; then
     echo -e "# ${Green}${#LOCAL_TOP_SUBVOLUMES[@]} ${IWhite}btrfs top volumes will be included ${Purple}$(printf "%+$(( COLS - 37 - $(echo ${#LOCAL_TOP_SUBVOLUMES[@]} | wc -m ) ))s" '#')"
     echo -e "${Purple}# ${IWhite}btrfs top volumes: ${Green}${LOCAL_TOP_SUBVOLUMES[@]} ${Purple}$(printf "%+$(( COLS - 21 - $(echo ${LOCAL_TOP_SUBVOLUMES[@]} | wc -m ) ))s" '#')"
@@ -2017,6 +2020,9 @@ function update_img() {
   echo -e "# ${IWhite}Updating backup img: ${Purple}$(printf "%+$(( COLS - 23 ))s" '#')"
   echo -e "# ${Green}$IMG_FILE ${Purple}$(printf "%+$(( COLS - 2 - $(echo ${IMG_FILE} | wc -m ) ))s" '#')"
   echo -e "# ${Green}$FSTYPE ${IWhite}filesystem detected on root ${Purple}$(printf "%+$(( COLS - 30 - $(echo ${FSTYPE} | wc -m ) ))s" '#')"
+  if [ "$RSYNC_DELETE" != '--delete' ]; then
+    echo -e "# ${Green}--fix ${IWhite}option selected, ${Green}rsync using --delete-before & --fsync options${Purple}$(printf "%+$(( COLS - 70 ))s" '#')"
+  fi
   if [ "$FSTYPE" == 'btrfs' ]; then
     echo -e "# ${Green}${#LOCAL_TOP_SUBVOLUMES[@]} ${IWhite}btrfs top volumes will be included ${Purple}$(printf "%+$(( COLS - 37 - $(echo ${#LOCAL_TOP_SUBVOLUMES[@]} | wc -m ) ))s" '#')"
     echo -e "${Purple}# ${IWhite}btrfs top volumes: ${Green}${LOCAL_TOP_SUBVOLUMES[@]} ${Purple}$(printf "%+$(( COLS - 21 - $(echo ${LOCAL_TOP_SUBVOLUMES[@]} | wc -m ) ))s" '#')"
@@ -2376,7 +2382,7 @@ function print_result() {
     echo -e "# ${IWhite}Image size: ${Green}${AFTER_SIZE}MiB ${IWhite}with a ${Green}root partition ${IWhite}of ${Green}${print_temp}MiB ${Purple}$(printf "%+$(( COLS - 45 - $(echo ${AFTER_SIZE} | wc -m ) - $(echo ${print_temp} | wc -m ) ))s" '#')"
     debug 'INFO' "$IMG_FILE is ${AFTER_SIZE}MiB"
   fi
-  if [ "$AUTOEXPAND" = true ] && [ "$OS" != 'armbian' ] && [ "$OS" != 'kali' ]; then
+  if [ "$AUTOEXPAND" = true ] && [ "$OS" != 'armbian' ] && [ "$OS" != 'kali' ] && [ "$OS" != 'ubuntu' ]; then
     echo -e "# ${Yellow}Please wait for the system to reboot after restoring an image with autoexpansion ${Purple}$(printf "%+$(( COLS - 83 ))s" '#')"
   fi
   echo -e "${Purple}${BREAK}"
@@ -2603,12 +2609,17 @@ elif grep -qsi 'archlinuxarm' /etc/os-release; then
   debug 'INFO' 'ArchLinux-arm detected'
   $SLEEPING
 elif grep -qsi 'kali' /etc/os-release; then
-  echo -e "${White}## ${Green}Kali-ARM detected"
+  echo -e "${White}## ${Green}Kali-arm detected"
   OS='kali'
-  debug 'INFO' 'Kali-ARM detected'
+  debug 'INFO' 'Kali-arm detected'
+  $SLEEPING
+elif grep -qsi 'ubuntu' /etc/os-release; then
+  echo -e "${White}## ${Green}Ubuntu detected"
+  OS='ubuntu'
+  debug 'INFO' 'Ubuntu detected'
   $SLEEPING
 else
-  echo -e "${Yellow}!! Unknown OS"
+  echo -e "${Yellow}!! Unknown OS, no autoexpansion available"
   OS='unknown'
   debug 'INFO' 'Unknown OS'
   $SLEEPING
@@ -2635,7 +2646,7 @@ if [ "$DEBUG" = true ]; then
   debug 'BREAK'
 fi
 
-# Check if usage of exclude.txt is requested
+# Check if exclude.txt exists when usage is requested
 if [ "$EXCLUDE_FILE" = true ]; then
   debug 'INFO' "-t selected by user, using $EXCLUDE_FILE_LOCATION"
   if ! [ -f "$EXCLUDE_FILE_LOCATION" ]; then
@@ -2673,8 +2684,17 @@ if [ "$AUTOEXPAND" = true ]; then
     manjaro-arm) echo -e "${White}## ${IWhite}Enabling autoexpansion for ${Green}Manjaro-arm..."; debug 'INFO' 'Running function: autoexpansion_manjaro'; autoexpansion_manjaro;;
     archlinux-arm) echo -e "${White}## ${IWhite}Enabling autoexpansion for ${Green}ArchLinux-arm..."; debug 'INFO' 'Running function: autoexpansion_arch'; autoexpansion_arch;;
     kali) echo -e "${White}## ${IWhite}Enabling autoexpansion for ${Green}Kali-ARM..."; debug 'INFO' 'Running function: autoexpansion_kali'; autoexpansion_kali;;
+    ubuntu) echo -e "${White}## ${Green}Making sure autoexpansion is enabled in /etc/cloud/cloud.cfg on img"; debug 'INFO' "Making sure autoexpansion is enabled in ${TMP_DIR}/etc/cloud/cloud.cfg"
+      sed -i 's/^[# ]*- growpart/  - growpart/' ${TMP_DIR}/etc/cloud/cloud.cfg
+      sed -i 's/^[# ]*- resizefs/  - resizefs/' ${TMP_DIR}/etc/cloud/cloud.cfg;;
     unknown) echo -e "${Yellow}!! No autoexpand option available for this OS!"; debug 'WARNING' 'No autoexpand option available for this OS'; AUTOEXPAND='failed';;
   esac
+elif [ "$AUTOEXPAND" = false ] && [ "$OS" == 'ubuntu' ]; then
+  debug 'INFO' "Disable autoexpansion requested & Ubuntu detected, making sure autoexpansion is disabled in ${TMP_DIR}/etc/cloud/cloud.cfg"
+  echo -e "${White}## ${Green}Making sure autoexpansion is disabled in /etc/cloud/cloud.cfg on img"
+  $SLEEPING
+  sed -i 's/^[ ]*- growpart/# - growpart/' ${TMP_DIR}/etc/cloud/cloud.cfg
+  sed -i 's/^[ ]*- resizefs/# - resizefs/' ${TMP_DIR}/etc/cloud/cloud.cfg
 fi
 
 print_result

--- a/shrink-backup
+++ b/shrink-backup
@@ -1339,11 +1339,11 @@ function do_rsync() {
       rsync -ahvHAX --exclude-from="$EXCLUDE_FILE_LOCATION" --exclude={${IMG_PATH}/*,${TMP_DIR},${tmp_file}} --info=progress2 --stats "$RSYNC_DELETE" --force --partial --delete-excluded --timeout=30 / "$TMP_DIR" 2>&1 | tee /dev/null > "$tmp_file"
     fi
   else
-    debug 'DEBUG' "Running: rsync -ahvHAX --exclude={/lost+found,/proc/*,/sys/*,/dev/*,/tmp/*,/run/*,/mnt/*,/media/*,/var/swap,${IMG_PATH}/*} --info=progress2 --stats "$RSYNC_DELETE" --force --partial --delete-excluded --timeout=10 / $TMP_DIR"
+    debug 'DEBUG' "Running: rsync -ahvHAX --exclude={/lost+found,/proc/*,/sys/*,/dev/*,/tmp/*,/run/*,/mnt/*,/media/*,/var/swap,/snap/*,${IMG_PATH}/*} --info=progress2 --stats "$RSYNC_DELETE" --force --partial --delete-excluded --timeout=10 / $TMP_DIR"
     if [ "$RSYNC_TTY" = true ]; then
-      rsync -ahvHAX --exclude={/lost+found,/proc/*,/sys/*,/dev/*,/tmp/*,/run/*,/mnt/*,/media/*,/var/swap,${IMG_PATH}/*} --info=progress2 --stats "$RSYNC_DELETE" --force --partial --delete-excluded --timeout=30 / "$TMP_DIR" 2>&1 | tee "$TTY_AVAILABILITY" > "$tmp_file"
+      rsync -ahvHAX --exclude={/lost+found,/proc/*,/sys/*,/dev/*,/tmp/*,/run/*,/mnt/*,/media/*,/var/swap,/snap/*,${IMG_PATH}/*} --info=progress2 --stats "$RSYNC_DELETE" --force --partial --delete-excluded --timeout=30 / "$TMP_DIR" 2>&1 | tee "$TTY_AVAILABILITY" > "$tmp_file"
     else
-      rsync -ahvHAX --exclude={/lost+found,/proc/*,/sys/*,/dev/*,/tmp/*,/run/*,/mnt/*,/media/*,/var/swap,${IMG_PATH}/*} --info=progress2 --stats "$RSYNC_DELETE" --force --partial --delete-excluded --timeout=30 / "$TMP_DIR" 2>&1 | tee /dev/null > "$tmp_file"
+      rsync -ahvHAX --exclude={/lost+found,/proc/*,/sys/*,/dev/*,/tmp/*,/run/*,/mnt/*,/media/*,/var/swap,/snap/*,${IMG_PATH}/*} --info=progress2 --stats "$RSYNC_DELETE" --force --partial --delete-excluded --timeout=30 / "$TMP_DIR" 2>&1 | tee /dev/null > "$tmp_file"
     fi
   fi
 

--- a/shrink-backup
+++ b/shrink-backup
@@ -1204,6 +1204,7 @@ function make_img() {
   fi
   $SLEEPING
   debug 'INFO' 'Using dd to create bootsector'
+  debug 'DEBUG' "Running: dd bs=512 count=$LOCAL_DDBOOTSECTOR if=$LOCAL_DEV_PATH of=$IMG_FILE conv=noerror,sync status=progress"
   if ! output=$(dd bs=512 count=$LOCAL_DDBOOTSECTOR if="$LOCAL_DEV_PATH" of="$IMG_FILE" conv=noerror,fsync status=progress 2>&1 | tee "$TTY_AVAILABILITY") && sync; then
     echo -e "${Yellow}$output\n${Red}!! DD TO LOCAL_BOOTSECTOR FAILED!!!"
     debug 'BREAK'
@@ -1212,7 +1213,7 @@ function make_img() {
   fi
   output=$(echo "$output" | tail -3 )
   debug 'BREAK'
-  debug 'DEBUG' "Running: dd bs=512 count=$LOCAL_DDBOOTSECTOR if=$LOCAL_DEV_PATH of=$IMG_FILE conv=noerror,sync status=progress\n$output\n------------------------------------------------------------------------------"
+  debug 'DEBUG' "dd completed:\n$output\n------------------------------------------------------------------------------"
   $SLEEPING
 
   # Truncate file to correct size

--- a/shrink-backup
+++ b/shrink-backup
@@ -195,9 +195,11 @@ UPDATE=false
 if [ "$INSTALL_METHOD" = 'curl' ]; then
   LOG_FILE='/var/log/shrink-backup.log'
   EXCLUDE_FILE_LOCATION='/usr/local/etc/shrink-backup.conf'
+  EXCLUDE_FILE_LOCATION_BTRFS='/usr/local/etc/shrink-backup_btrfs.conf'
 else
   LOG_FILE="$(dirname $0)/shrink-backup.log"
   EXCLUDE_FILE_LOCATION="$(dirname $0)/exclude.txt"
+  EXCLUDE_FILE_LOCATION_BTRFS="$(dirname $0)/exclude_btrfs.txt"
 fi
 AUTORESIZE_WARNING=false
 ZOOM=false
@@ -262,7 +264,7 @@ Directory where .img file is created is automatically excluded in backup
 Usage: ${Green}sudo $(basename "$0") [options] imagefile.img [extra space (MiB)]
   -U             ${IWhite}Update existing img file (rsync to existing img)
                    Optional [extra space] extends img root partition
-  ${Green}-a             ${IWhite}Autocalculate root size partition, [extra space] is ignored
+  ${Green}-a             ${IWhite}Autocalculate root size partition, [extra space] is ignored.
                    When used in combination with -U:
                    Expand if partition is >=256MiB smaller than autocalculated recommended minimum
                    Shrink if partition is >=512MiB bigger than autocalculated recommended minimum
@@ -277,6 +279,7 @@ Usage: ${Green}sudo $(basename "$0") [options] imagefile.img [extra space (MiB)]
   ${Green}-q --quiet     ${IWhite}Do not print rsync copy process
   ${Green}--no-color     ${IWhite}Run script without color formatted text
   ${Green}--fix          ${IWhite}Try to fix the img file if -a fails with a "broken pipe" error
+                   Will activate rsync options --delete-before & --fsync
   ${Green}--rsync        ${IWhite}Define custom rsync line manually. Will print rsync line for user to edit
   ${Green}--loop [img]   ${IWhite}Loop img file and exit, works in combination with -l & -z
                    If optional [extra space] is defined, the img file will be extended with the amount before looping
@@ -328,7 +331,7 @@ while true; do
     -l) DEBUG=true; shift;;
     -z) ZOOM=true; shift;;
     -q|--quiet) RSYNC_TTY=false; shift;;
-    --fix) RSYNC_DELETE='--delete-before'; shift;;
+    --fix) RSYNC_DELETE='--delete-before --fsync'; shift;;
     --f2fs) F2FS_CONVERSION=true; shift;;
     --no-color) unset White IWhite Red Blue Green Yellow Purple NC; COLORS=false; debug 'DEBUG' '--no-color selected by user, unsetting color variables'; shift;;
     --rsync) RSYNC_CUSTOM=true; shift;;
@@ -358,7 +361,7 @@ COLS=85
 if [ $(echo "$IMG_FILE" | wc -m) -gt $(( COLS - 19 )) ]; then
   COLS=$(( $(echo "$IMG_FILE" | wc -m) + 20 ))
 fi
-if [ $(tput cols) -lt "$COLS" ]; then
+if [ -t 0 ] && [ $(tput cols) -lt "$COLS" ]; then # tput will fail in webmin
   COLS=$(tput cols)
 fi
 BREAK="$(printf %${COLS}s | tr ' ' '#')"
@@ -711,38 +714,62 @@ function btrfs_variables() {
   declare -ag LOCAL_NESTED_SUBVOLUMES=( $(btrfs subvolume list / --sort=path | grep -v ' 5 ' | awk '{print $9}') )
   debug 'DEBUG' "LOCAL_NESTED_SUBVOLUMES=$(echo ${LOCAL_NESTED_SUBVOLUMES[@]})"
 
-  if [ "$EXCLUDE_FILE" = true ]; then
-    # Filter out top subvolumes not in fstab
-    debug 'INFO' 'Filtering out top level 5 subvolumes not existing in fstab'
+  # Filter out top subvolumes not in fstab
+  debug 'INFO' 'Filtering out top level 5 subvolumes not existing in fstab'
+  for i in ${!LOCAL_TOP_SUBVOLUMES[@]}; do
+    subvol=${LOCAL_TOP_SUBVOLUMES[i]}
+    if $(echo $subvol | grep -q -v -f /etc/fstab); then
+      debug 'DEBUG' "Filtering out subvolume: $subvol"
+      unset LOCAL_TOP_SUBVOLUMES[i]
+    fi
+  done
+  debug 'DEBUG' "After filtering: LOCAL_TOP_SUBVOLUMES=$(echo ${LOCAL_TOP_SUBVOLUMES[@]})"
+
+  # Filter out top subvolumes from exclude_btrfs.txt or shrink-backup_btrfs.conf
+  if [ -f "$EXCLUDE_FILE_LOCATION_BTRFS" ]; then
+    debug 'INFO' 'Filtering out top level 5 subvolumes to exclude from exclude_btrfs.txt or shrink-backup_btrfs.conf'
     for i in ${!LOCAL_TOP_SUBVOLUMES[@]}; do
       subvol=${LOCAL_TOP_SUBVOLUMES[i]}
-      if $(echo $subvol | grep -q -v -f /etc/fstab); then
+      if $(echo $subvol | grep -q -f "$EXCLUDE_FILE_LOCATION_BTRFS"); then
+        SUBVOLUME_EXCLUDE_PATHS+=( $(cat /etc/fstab | grep $subvol | awk 'print $2') )
+        debug 'DEBUG' "Adding $(cat /etc/fstab | grep $subvol | awk 'print $2') to SUBVOLUME_EXCLUDE_PATHS"
         debug 'DEBUG' "Filtering out subvolume: $subvol"
         unset LOCAL_TOP_SUBVOLUMES[i]
       fi
     done
     debug 'DEBUG' "After filtering: LOCAL_TOP_SUBVOLUMES=$(echo ${LOCAL_TOP_SUBVOLUMES[@]})"
 
-    # Filter out top subvolumes from exclude.txt or shrink-backup.conf
-    debug 'INFO' 'Filtering out top level 5 subvolumes to exclude from exclude.txt or shrink-backup.conf'
-    for i in ${!LOCAL_TOP_SUBVOLUMES[@]}; do
-      subvol=${LOCAL_TOP_SUBVOLUMES[i]}
-      if $(echo $subvol | grep -q -f "$EXCLUDE_FILE_LOCATION"); then
-        debug 'DEBUG' "Filtering out subvolume: $subvol"
-        unset LOCAL_TOP_SUBVOLUMES[i]
-      fi
-    done
-    debug 'DEBUG' "After filtering: LOCAL_TOP_SUBVOLUMES=$(echo ${LOCAL_TOP_SUBVOLUMES[@]})"
-
-    # Filter out nested subvolumes from exclude.txt or shrink-backup.conf
-    debug 'INFO' 'Filtering out nested subvolumes to exclude from exclude.txt or shrink-backup.conf'
+    # Filter out nested subvolumes from exclude_btrfs.txt or shrink-backup_btrfs.conf
+    debug 'INFO' 'Filtering out nested subvolumes to exclude from exclude_btrfs.txt or shrink-backup_btrfs.conf'
     for i in ${!LOCAL_NESTED_SUBVOLUMES[@]}; do
       subvol=${LOCAL_NESTED_SUBVOLUMES[i]}
-      if $(echo $subvol | grep -q -f "$EXCLUDE_FILE_LOCATION"); then
+      if $(echo $subvol | grep -qxE -f "$EXCLUDE_FILE_LOCATION_BTRFS"); then
         debug 'DEBUG' "Filtering out subvolume: $subvol"
+
+        # Fix path if nested subvolume is in other location than root subvolume
+        top_subvols="$(echo ${LOCAL_TOP_SUBVOLUMES[@]} | sed 's/ /|/g')" # convert spaces into |
+        if echo "$subvol" | grep -qE "$top_subvols"; then
+          debug 'INFO' 'Nested volume not under root, fixing path'
+          for top_subvol in ${LOCAL_TOP_SUBVOLUMES[@]}; do
+            if echo "$subvol" | grep -qw "$top_subvol"; then
+              break
+            fi
+          done
+          path="$(cat /etc/fstab | grep $top_subvol | awk '{print $2}')"
+          subvol="$(echo $subvol | sed "s|$top_subvol|$path|g")"
+        fi
+        if [[ "$subvol" != /* ]]; then
+          subvol="/$subvol"
+        fi
+        debug 'DEBUG' "Adding $subvol to SUBVOLUME_EXCLUDE_PATHS"
+        SUBVOLUME_EXCLUDE_PATHS+=($subvol)
         unset LOCAL_NESTED_SUBVOLUMES[i]
       fi
     done
+    if [ -n "$SUBVOLUME_EXCLUDE_PATHS" ]; then
+      SUBVOLUME_EXCLUDE_PATHS=",$(echo ${SUBVOLUME_EXCLUDE_PATHS[@]} | sed 's/ /,/g')"
+      debug 'DEBUG' "SUBVOLUME_EXCLUDE_PATHS=$SUBVOLUME_EXCLUDE_PATHS)"
+    fi
     debug 'DEBUG' "After filtering: LOCAL_NESTED_SUBVOLUMES=$(echo ${LOCAL_NESTED_SUBVOLUMES[@]})"
   fi
 return 0
@@ -831,6 +858,54 @@ function img_variables() {
       exit 3
     fi
   fi
+return 0
+}
+
+
+
+# Set default RSYNC_LINE
+function rsync_line() {
+
+  IMG_PATH=$(dirname "$IMG_FILE")
+  debug 'INFO' 'Creating temp directory'
+  debug 'DEBUG' "Running: mktemp -d -t backup-XXX"
+  TMP_DIR=$(mktemp -d -t backup-XXX)
+  debug 'DEBUG' "TMP_DIR=$TMP_DIR"
+  debug 'INFO' 'Creating temp file to store rsync output'
+  debug 'DEBUG' 'Running: mktemp -t rsync-XXX'
+  tmp_file=$(mktemp -t rsync-XXX)
+  debug 'DEBUG' "tmp_file=$tmp_file"
+  if [ "$RSYNC_TTY" = false ]; then
+    RSYNC_PATHS="/ $TMP_DIR 2>&1 | tee /dev/null > $tmp_file"
+  else
+    RSYNC_PATHS="/ $TMP_DIR 2>&1 | tee $TTY_AVAILABILITY > $tmp_file"
+  fi
+  debug 'DEBUG' "RSYNC_PATHS=$RSYNC_PATHS"
+
+  if [ "$EXCLUDE_FILE" = true ]; then
+    RSYNC_LINE="rsync -ahvHAX --exclude-from=$EXCLUDE_FILE_LOCATION --exclude={${IMG_PATH}/*,${TMP_DIR},${tmp_file},${BOOT_PATH}/shrink-backup.lock${SUBVOLUME_EXCLUDE_PATHS}} --info=progress2 --stats $RSYNC_DELETE --force --partial --delete-excluded --timeout=30"
+  else
+    RSYNC_LINE="rsync -ahvHAX --exclude={/lost+found,/proc/*,/sys/*,/dev/*,/tmp/*,/run/*,/mnt/*,/media/*,/var/swap,/snap/*,${IMG_PATH}/*,${BOOT_PATH}/shrink-backup.lock${SUBVOLUME_EXCLUDE_PATHS}} --info=progress2 --stats $RSYNC_DELETE --force --partial --delete-excluded --timeout=30"
+  fi
+  debug 'DEBUG' "RSYNC_LINE=$RSYNC_LINE"
+
+  # If --rsync is selected, ask for user configuration
+  if [ "$RSYNC_CUSTOM" = true ]; then
+    echo -e "${Yellow}## Custom rsync line option selected"
+    echo -e "${White}## ${IWhite}Default rsync line: ${Green}${RSYNC_LINE}"
+    echo -e "${White}## ${IWhite}Edit line to use in script ${Yellow}(press ctrl+c to abort)${NC}"
+    printf %${COLUMNS}s | tr ' ' '#'
+
+    read -e -i "$RSYNC_LINE" input
+    RSYNC_CUSTOM_LINE="$input"
+    RSYNC_LINE="$input"
+    debug 'DEBUG' "RSYNC_CUSTOM_LINE=$RSYNC_CUSTOM_LINE"
+  fi
+
+  # Add RSYNC_PATHS to RSYNC_LINE
+  debug 'INFO' 'Combining RSYNC_LINE & RSYNC_PATHS'
+  RSYNC_LINE="$(echo -e $RSYNC_LINE $RSYNC_PATHS)"
+  debug 'DEBUG' "RSYNC_LINE=$RSYNC_LINE"
 return 0
 }
 
@@ -1089,7 +1164,8 @@ function do_mount() {
       exit 3
     fi
 
-    # Mount top subvolums (except @). New top volumes will not be created during an update, if new top volumes have been created on device script will exit
+    # Mount top subvolumes (except @). New top volumes will not be created during an update, if new top volumes have been created on device script will fail and exit
+    debug 'INFO' 'Mounting non-root subvolumes from loop (if existing)'
     for subvol in "${LOCAL_TOP_SUBVOLUMES[@]}"; do
       # Excluding root (@) subvolume and mounting all else in fstab
       if grep -q "$subvol" /etc/fstab && [[ "$subvol" != '@' ]]; then
@@ -1114,17 +1190,18 @@ function do_mount() {
     if [[ $(echo $(btrfs subvolume list "$TMP_DIR" --sort=path | grep -v ' 5 ' | awk '{print $9}') ) != "${LOCAL_NESTED_SUBVOLUMES[@]}" ]]; then
       echo -e "${White}## ${IWhite}Managing nested subvolumes..."
       $SLEEPING
+      debug 'INFO' 'Managing nested subvolumes'
       IMG_NESTED_SUBVOLUMES=( $(btrfs subvolume list "$TMP_DIR" --sort=path | grep -v ' 5 ' | awk '{print $9}') )
       debug 'DEBUG' "IMG_NESTED_SUBVOLUMES=$(echo ${IMG_NESTED_SUBVOLUMES[@]})"
 
-      # Create new nested subvolume(s)
+      # Create new nested subvolume(s) if needed
       for subvol in ${LOCAL_NESTED_SUBVOLUMES[@]}; do
-        if ! echo "${IMG_NESTED_SUBVOLUMES[@]}" | grep -q "$subvol"; then
+        if ! printf '%s\n' "${IMG_NESTED_SUBVOLUMES[@]}" | grep -qx $subvol; then
           echo -e "${White}## ${IWhite}Creating nested subvolume: ${Green}$subvol"
           $SLEEPING
           # Fix path if nested subvolume is in other location than root subvolume
           top_subvols="$(echo ${LOCAL_TOP_SUBVOLUMES[@]} | sed 's/ /|/g')" # convert spaces into |
-          if echo "$subvol" | grep -E "$top_subvols"; then
+          if echo "$subvol" | grep -qE "$top_subvols"; then
             debug 'INFO' 'Nested volume not under root, fixing path'
             for top_subvol in ${LOCAL_TOP_SUBVOLUMES[@]}; do
               if echo "$subvol" | grep -qw "$top_subvol"; then
@@ -1147,11 +1224,13 @@ function do_mount() {
             exit 3
           fi
         fi
+        IMG_NESTED_SUBVOLUMES=( $(btrfs subvolume list "$TMP_DIR" --sort=path | grep -v ' 5 ' | awk '{print $9}') )
+        debug 'DEBUG' "IMG_NESTED_SUBVOLUMES=$(echo ${IMG_NESTED_SUBVOLUMES[@]})"
       done
 
-      # Delete nested img subvolume(s)
+      # Delete nested img subvolume(s) if needed
       for subvol in ${IMG_NESTED_SUBVOLUMES[@]}; do
-        if ! echo "${LOCAL_NESTED_SUBVOLUMES[@]}" | grep -q "$subvol"; then
+        if ! printf '%s\n' "${LOCAL_NESTED_SUBVOLUMES[@]}" | grep -qx $subvol; then
           echo -e "${White}## ${IWhite}Deleting nested subvolume: ${Green}$subvol"
           $SLEEPING
           # Fix path if nested subvolume is in other location than root subvolume
@@ -1175,6 +1254,8 @@ function do_mount() {
           fi
         fi
       done
+      IMG_NESTED_SUBVOLUMES=( $(btrfs subvolume list "$TMP_DIR" --sort=path | grep -v ' 5 ' | awk '{print $9}') )
+      debug 'DEBUG' "IMG_NESTED_SUBVOLUMES=$(echo ${IMG_NESTED_SUBVOLUMES[@]})"
     fi
   fi
 
@@ -1415,7 +1496,6 @@ function do_rsync() {
   if [ "$TTY_AVAILABILITY" == '/dev/null' ] || [ "$RSYNC_TTY" = false ]; then
     echo -e "${White}## ${Yellow}This might take some time, please stand by..."
   fi
-  IMG_PATH=$(dirname "$IMG_FILE")
   debug 'DEBUG' "Backing up to ${IMG_PATH}${IMG_FILE}"
 
   # Run rsync
@@ -1431,6 +1511,7 @@ function do_rsync() {
   elif [ "${PIPESTATUS[0]}" -eq 23 ]; then
     echo -e "${White}## ${Yellow}Warning, rsync code 23, some files vanished before they could be transferred (code 24) at main.c"
     echo -e "${White}## ${Yellow}This does NOT mean the backup failed"
+    $SLEEPING
     debug 'WARNING' 'rsync code 23, some files vanished before they could be transferred (code 24) at main.c'
   fi
 
@@ -1523,7 +1604,10 @@ return 0
 function make_img() {
 
   debug 'INFO' 'Running function: dev_variables'
+  # btrfs_variables is run within dev_variables
   dev_variables
+  debug 'INFO' 'Running function: rsync_line'
+  rsync_line
 
   # Display information
   echo -e "${Purple}$BREAK"
@@ -1885,10 +1969,10 @@ function update_img() {
   debug 'INFO' 'Running function: dev_variables'
   # btrfs_variables is run within dev_variables
   dev_variables
-
+  debug 'INFO' 'Running function: rsync_line'
+  rsync_line
   debug 'INFO' 'Running function: do_loop'
   do_loop
-
   debug 'INFO' 'Running function: img_variables'
   img_variables
 
@@ -2563,48 +2647,6 @@ if [ "$EXCLUDE_FILE" = true ]; then
 else
   debug 'INFO' '-t NOT selected by user, using default exclude directories'
 fi
-
-# Set default RSYNC_LINE
-IMG_PATH=$(dirname "$IMG_FILE")
-debug 'INFO' 'Creating temp directory'
-debug 'DEBUG' "Running: mktemp -d -t backup-XXX"
-TMP_DIR=$(mktemp -d -t backup-XXX)
-debug 'DEBUG' "TMP_DIR=$TMP_DIR"
-debug 'INFO' 'Creating temp file to store rsync output'
-debug 'DEBUG' 'Running: mktemp -t rsync-XXX'
-tmp_file=$(mktemp -t rsync-XXX)
-debug 'DEBUG' "tmp_file=$tmp_file"
-if [ "$RSYNC_TTY" = false ]; then
-  RSYNC_PATHS="/ $TMP_DIR 2>&1 | tee /dev/null > $tmp_file"
-else
-  RSYNC_PATHS="/ $TMP_DIR 2>&1 | tee $TTY_AVAILABILITY > $tmp_file"
-fi
-debug 'DEBUG' "RSYNC_PATHS=$RSYNC_PATHS"
-
-if [ "$EXCLUDE_FILE" = true ]; then
-  RSYNC_LINE="rsync -ahvHAX --exclude-from=$EXCLUDE_FILE_LOCATION --exclude={${IMG_PATH}/*,${TMP_DIR},${tmp_file},${BOOT_PATH}/shrink-backup.lock} --info=progress2 --stats $RSYNC_DELETE --force --partial --delete-excluded --timeout=30"
-else
-  RSYNC_LINE="rsync -ahvHAX --exclude={/lost+found,/proc/*,/sys/*,/dev/*,/tmp/*,/run/*,/mnt/*,/media/*,/var/swap,/snap/*,${IMG_PATH}/*,${BOOT_PATH}/shrink-backup.lock} --info=progress2 --stats $RSYNC_DELETE --force --partial --delete-excluded --timeout=30"
-fi
-debug 'DEBUG' "RSYNC_LINE=$RSYNC_LINE"
-
-# If --rsync is selected, ask for user configuration
-if [ "$RSYNC_CUSTOM" = true ]; then
-  echo -e "${Yellow}## Custom rsync line option selected"
-  echo -e "${White}## ${IWhite}Default rsync line: ${Green}${RSYNC_LINE}"
-  echo -e "${White}## ${IWhite}Edit line to use in script ${Yellow}(press ctrl+c to abort)${NC}"
-  printf %${COLUMNS}s | tr ' ' '#'
-
-  read -e -i "$RSYNC_LINE" input
-  RSYNC_CUSTOM_LINE="$input"
-  RSYNC_LINE="$input"
-  debug 'DEBUG' "RSYNC_CUSTOM_LINE=$RSYNC_CUSTOM_LINE"
-fi
-
-# Add RSYNC_PATHS to RSYNC_LINE
-debug 'INFO' 'Combining RSYNC_LINE & RSYNC_PATHS'
-RSYNC_LINE="$(echo -e $RSYNC_LINE $RSYNC_PATHS)"
-debug 'DEBUG' "RSYNC_LINE=$RSYNC_LINE"
 
 # Check dependencies
 debug 'INFO' 'Running function: check_dependencies'

--- a/shrink-backup
+++ b/shrink-backup
@@ -126,9 +126,9 @@ function cleanup() {
     echo -e "${White}## ${IWhite}Elapsed time: ${Green}$(date -d@$SECONDS -u +%M.%S)${NC}"
     debug 'INFO' "Elapsed time: $(date -d@$SECONDS -u +%M.%S)"
     debug 'DEBUG' 'Exiting script'
-    if [ "$DEBUG" = true ]; then
-      echo '#####################################################################################' >> "$LOG_FILE"
-    fi
+  fi
+  if [ "$DEBUG" = true ]; then
+    echo '#####################################################################################' >> "$LOG_FILE"
   fi
 }
 trap cleanup EXIT SIGTERM
@@ -2542,9 +2542,9 @@ fi
 
 # Check if usage of exclude.txt is requested
 if [ "$EXCLUDE_FILE" = true ]; then
-  debug 'INFO' "-f selected by user, using $EXCLUDE_FILE_LOCATION"
+  debug 'INFO' "-t selected by user, using $EXCLUDE_FILE_LOCATION"
   if ! [ -f "$EXCLUDE_FILE_LOCATION" ]; then
-    echo -e "${Red}!! ERROR! ${Green}-f selected but ${Yellow}$EXCLUDE_FILE_LOCATION does not exist!"
+    echo -e "${Red}!! ERROR! ${Green}-t selected but ${Yellow}$EXCLUDE_FILE_LOCATION does not exist!"
     debug 'ERROR' "$EXCLUDE_FILE_LOCATION does not exist, exit 1"
     exit 1
   fi

--- a/shrink-backup
+++ b/shrink-backup
@@ -1015,11 +1015,11 @@ function do_rsync() {
   debug 'DEBUG' "tmp_file=$tmp_file"
 
   if [ "$EXCLUDE_FILE" = true ]; then
-    debug 'DEBUG' "Running: rsync -ahvHAX --exclude-from="$EXCLUDE_FILE_LOCATION" --exclude={${IMG_PATH}/*,${TMP_DIR},${tmp_file}} --info=progress2 --stats "$RSYNC_DELETE" --force --partial --delete-excluded / $TMP_DIR"
+    debug 'DEBUG' "Running: rsync -ahvHAX --exclude-from="$EXCLUDE_FILE_LOCATION" --exclude={${IMG_PATH}/*,${TMP_DIR},${tmp_file}} --info=progress2 --stats "$RSYNC_DELETE" --force --partial --delete-excluded --timeout=10 / $TMP_DIR"
     if [ "$RSYNC_TTY" = true ]; then
-      rsync -ahvHAX --exclude-from="$EXCLUDE_FILE_LOCATION" --exclude={${IMG_PATH}/*,${TMP_DIR},${tmp_file}} --info=progress2 --stats "$RSYNC_DELETE" --force --partial --delete-excluded / "$TMP_DIR" 2>&1 | tee "$TTY_AVAILABILITY" > "$tmp_file"
+      rsync -ahvHAX --exclude-from="$EXCLUDE_FILE_LOCATION" --exclude={${IMG_PATH}/*,${TMP_DIR},${tmp_file}} --info=progress2 --stats "$RSYNC_DELETE" --force --partial --delete-excluded --timeout=10 / "$TMP_DIR" 2>&1 | tee "$TTY_AVAILABILITY" > "$tmp_file"
     else
-      rsync -ahvHAX --exclude-from="$EXCLUDE_FILE_LOCATION" --exclude={${IMG_PATH}/*,${TMP_DIR},${tmp_file}} --info=progress2 --stats "$RSYNC_DELETE" --force --partial --delete-excluded / "$TMP_DIR" 2>&1 | tee /dev/null > "$tmp_file"
+      rsync -ahvHAX --exclude-from="$EXCLUDE_FILE_LOCATION" --exclude={${IMG_PATH}/*,${TMP_DIR},${tmp_file}} --info=progress2 --stats "$RSYNC_DELETE" --force --partial --delete-excluded --timeout=10 / "$TMP_DIR" 2>&1 | tee /dev/null > "$tmp_file"
     fi
 #     if [ "${PIPESTATUS[0]}" -ne 0 ] && [ "${PIPESTATUS[0]}" -ne 23 ]; then # code 23 = rsync warning: some files vanished before they could be transferred (code 24) at main.c
 #       output=$(tail -16 "$tmp_file")
@@ -1031,11 +1031,11 @@ function do_rsync() {
 #       debug 'WARNING' 'rsync code 23, some files vanished before they could be transferred (code 24) at main.c'
 #     fi
   else
-    debug 'DEBUG' "Running: rsync -ahvHAX --exclude={/lost+found,/proc/*,/sys/*,/dev/*,/tmp/*,/run/*,/mnt/*,/media/*,/var/swap,${IMG_PATH}/*} --info=progress2 --stats "$RSYNC_DELETE" --force --partial --delete-excluded / $TMP_DIR"
+    debug 'DEBUG' "Running: rsync -ahvHAX --exclude={/lost+found,/proc/*,/sys/*,/dev/*,/tmp/*,/run/*,/mnt/*,/media/*,/var/swap,${IMG_PATH}/*} --info=progress2 --stats "$RSYNC_DELETE" --force --partial --delete-excluded --timeout=10 / $TMP_DIR"
     if [ "$RSYNC_TTY" = true ]; then
-      rsync -ahvHAX --exclude={/lost+found,/proc/*,/sys/*,/dev/*,/tmp/*,/run/*,/mnt/*,/media/*,/var/swap,${IMG_PATH}/*} --info=progress2 --stats "$RSYNC_DELETE" --force --partial --delete-excluded / "$TMP_DIR" 2>&1 | tee "$TTY_AVAILABILITY" > "$tmp_file"
+      rsync -ahvHAX --exclude={/lost+found,/proc/*,/sys/*,/dev/*,/tmp/*,/run/*,/mnt/*,/media/*,/var/swap,${IMG_PATH}/*} --info=progress2 --stats "$RSYNC_DELETE" --force --partial --delete-excluded --timeout=10 / "$TMP_DIR" 2>&1 | tee "$TTY_AVAILABILITY" > "$tmp_file"
     else
-      rsync -ahvHAX --exclude={/lost+found,/proc/*,/sys/*,/dev/*,/tmp/*,/run/*,/mnt/*,/media/*,/var/swap,${IMG_PATH}/*} --info=progress2 --stats "$RSYNC_DELETE" --force --partial --delete-excluded / "$TMP_DIR" 2>&1 | tee /dev/null > "$tmp_file"
+      rsync -ahvHAX --exclude={/lost+found,/proc/*,/sys/*,/dev/*,/tmp/*,/run/*,/mnt/*,/media/*,/var/swap,${IMG_PATH}/*} --info=progress2 --stats "$RSYNC_DELETE" --force --partial --delete-excluded --timeout=10 / "$TMP_DIR" 2>&1 | tee /dev/null > "$tmp_file"
     fi
 #     if [ "${PIPESTATUS[0]}" -ne 0 ] && [ "${PIPESTATUS[0]}" -ne 23 ]; then # code 23 = rsync warning: some files vanished before they could be transferred (code 24) at main.c
 #       output=$(tail -16 "$tmp_file")

--- a/shrink-backup
+++ b/shrink-backup
@@ -1082,9 +1082,22 @@ function do_mount() {
   # Mount boot partition if exists
   if [ -n "$BOOT_PATH" ]; then
     if ! mount --fake | grep -q 'boot'; then
-      echo -e "${Red}!! Boot found in fstab but partition not mounted, please mount and retry script!!!"
-      debug 'ERROR' 'Boot found in fstab but partition not mounted, exit 3'
-      exit 3
+      while true; do
+        if [ "$COLORS" = true ]; then
+          echo -e "${Red}!! Boot found in fstab but partition not mounted..."
+          debug 'WARNING' 'Boot found in fstab but partition not mounted'
+          debug 'INFO' 'Do you want to mount boot partition?'
+          read -r -p $'\e[0;37m## \e[0;97mDo you want to mount boot partition? \e[0;92m[y/n] \e[0m' input
+        else
+          read -r -p '## Do you want to mount boot partition? [y/n] ' input
+        fi
+        case $input in
+          [Yy]) debug 'DEBUG' "Y or y pressed to confirm, running: mount $LOCAL_DEV_BOOT_PATH $BOOT_PATH"; mount "$LOCAL_DEV_BOOT_PATH" "$BOOT_PATH"; break;;
+          [Nn]) echo -e "${Red}!! Aborting..."; exit 3;;
+          *) echo -e "${Yellow}!! ${Red}ERROR! ${Yellow}Please enter ${Green}'y' ${Yellow}or ${Green}'n'${Yellow}"; debug 'WARNING' "ERROR, please enter 'y' or 'n'";;
+        esac
+      done
+    sleep 1
     fi
     echo -e "${White}## ${IWhite}Mounting img boot partition..."
     $SLEEPING

--- a/shrink-backup
+++ b/shrink-backup
@@ -46,6 +46,11 @@ function cleanup() {
   # exit 10 = stopped by user (ctrl+c)
   local exit_code="$?"
 
+  # Kill tail operation hindering unmounting of boot partition & delete lock file
+  debug 'DEBUG' "Killing tail operation and removing ${BOOT_PATH}/shrink-backup.lock"
+  pkill tail
+  rm "$BOOT_PATH"/shrink-backup.lock 2>/dev/null
+
   if [ "$exit_code" -ne 1 ] && [ "$exit_code" -ne 2 ]; then
     case $exit_code in
       0) debug 'DEBUG' 'Cleanup function called with exit 0';;
@@ -138,10 +143,6 @@ function cleanup() {
   if [ "$DEBUG" = true ]; then
     echo '#####################################################################################' >> "$LOG_FILE"
   fi
-
-  # kill tail operation hindering unmounting of boot partition & delete lock file
-  pkill tail
-  rm "$BOOT_PATH"/shrink-backup.lock
 }
 trap cleanup EXIT SIGTERM
 trap "exit 10" SIGINT
@@ -457,8 +458,6 @@ function chrootrun() {
       (( count -- ))
       debug 'INFO' 'Boot partition found in fstab, mounting img boot partition'
       fstab=($(cat "$TMP_DIR"/etc/fstab | grep 'boot'))
-#       BOOT_PATH="${fstab[1]}" # Used to find mount in cleanup function
-#       debug 'DEBUG' "BOOT_PATH=$BOOT_PATH"
       echo -e "${White}## ${IWhite}Mounting img ${Green}${fstab[1]} ${IWhite}from fstab"
       $SLEEPING
       debug 'DEBUG' "Running: mount -o ${fstab[3]} ${LSBLK_PARTITIONS[$count]} ${TMP_DIR}${fstab[1]}"
@@ -497,8 +496,6 @@ function chrootrun() {
     fi
     # Assumes boot exists and is on first partition
     fstab=($(cat "$TMP_DIR"/etc/fstab | grep 'boot'))
-#     BOOT_PATH="${fstab[1]}" # Used to find mount in cleanup function
-#     debug 'DEBUG' "BOOT_PATH=$BOOT_PATH"
     debug 'INFO' 'Mounting img boot partition'
     echo -e "${White}## ${IWhite}Mounting img ${Green}${fstab[1]} ${IWhite}from fstab"
     $SLEEPING
@@ -562,7 +559,6 @@ function dev_variables() {
 
   # Check if separate boot and root partition exists and set variables accordingly
   if grep -q 'boot' /etc/fstab; then
-#     debug 'INFO' 'Separate boot partition detected'
     BOOT_PARTITION=true
     LOCAL_DEV_BOOT_PATH=$(mount --fake | grep 'boot' | awk '{print $1}')
     LOCAL_DEV_ROOT_PATH=$(mount --fake | grep ' / ' | awk '{print $1}')
@@ -571,8 +567,6 @@ function dev_variables() {
     LOCAL_ROOT_UUID=$(lsblk -no uuid "$LOCAL_DEV_ROOT_PATH")
     LOCAL_ROOT_PARTUUID=$(lsblk -no partuuid "$LOCAL_DEV_ROOT_PATH")
     debug 'DEBUG' "LOCAL_BOOT_UUID=$LOCAL_BOOT_UUID | LOCAL_ROOT_UUID=$LOCAL_ROOT_UUID | LOCAL_ROOT_PARTUUID=$LOCAL_ROOT_PARTUUID"
-#     BOOT_PATH=$(cat /etc/fstab | grep 'boot' | awk '{print $2}')
-#     debug 'DEBUG' "BOOT_PATH=$BOOT_PATH"
   else
     debug 'INFO' 'No boot partition detected'
     BOOT_PARTITION=false
@@ -1101,24 +1095,6 @@ function do_mount() {
 
   # Mount boot partition if exists
   if [ -n "$BOOT_PATH" ]; then
-#     if ! mount --fake | grep -q 'boot'; then
-#       while true; do
-#         if [ "$COLORS" = true ]; then
-#           echo -e "${Red}!! Boot found in fstab but partition not mounted..."
-#           debug 'WARNING' 'Boot found in fstab but partition not mounted'
-#           debug 'INFO' 'Do you want to mount boot partition?'
-#           read -r -p $'\e[0;37m## \e[0;97mDo you want to mount boot partition? \e[0;92m[y/n] \e[0m' input
-#         else
-#           read -r -p '## Do you want to mount boot partition? [y/n] ' input
-#         fi
-#         case $input in
-#           [Yy]) debug 'DEBUG' "Y or y pressed to confirm, running: mount $LOCAL_DEV_BOOT_PATH $BOOT_PATH"; mount "$LOCAL_DEV_BOOT_PATH" "$BOOT_PATH"; break;;
-#           [Nn]) echo -e "${Red}!! Aborting..."; exit 4;;
-#           *) echo -e "${Yellow}!! ${Red}ERROR! ${Yellow}Please enter ${Green}'y' ${Yellow}or ${Green}'n'${Yellow}"; debug 'WARNING' "ERROR, please enter 'y' or 'n'";;
-#         esac
-#       done
-#     sleep 1
-#     fi
     echo -e "${White}## ${IWhite}Mounting img boot partition..."
     $SLEEPING
     debug 'INFO' 'Mounting boot inside root'
@@ -2333,15 +2309,6 @@ function print_result() {
   echo -e "${Purple}${BREAK}"
   debug 'INFO' 'Backup done'
   debug 'BREAK'
-
-  # Make sure boot partition was not unmounted during backup
-#   if grep -q 'boot' /etc/fstab && ! mount --fake | grep -q "$LOCAL_DEV_BOOT_PATH"; then
-#     debug 'ERROR' "Boot partition ($IMG_DEV_BOOT_PATH) became unmounted during backup"
-#     echo -e "${Red}!! BOOT PARTITION BECAME UNMOUNTED DURING BACKUP SO THE IMG IS MOST LIKELY CORRUPT!!"
-#     echo -e "${Red}!! RE-RUN SHRINK-BACKUP WITH -U OPTION!!"
-#     echo -e "$Yellow## shrink-backup will mount the partition for you if you don't do so yourself"
-#     echo -e "$Yellow sudo ./shrink-backup -Ul $IMG_FILE"
-#   fi
 return 0
 }
 

--- a/shrink-backup
+++ b/shrink-backup
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 #
 # shrink-backup
-# Version 1.3-beta
+# Version 1.3
 # Backup tool for creating and updating .img files (with autoexpansion function) on various linux operating systems
 #
-#    Copyright (c) 2025, Marcus Johansson
+#    Copyright (c) 2024-present, Marcus Johansson
 #    https://github.com/UnconnectedBedna/shrink-backup
 #    All rights reserved.
 #
@@ -239,9 +239,9 @@ fi
 version() {
   echo -e "${Purple}#########################################################################
 #                                                                       #
-# ${Green}shrink-backup version 1.3-beta                                        ${Purple}#
+# ${Green}shrink-backup version 1.3                                             ${Purple}#
 #                                                                       #
-# ${IWhite}Copyright (c) 2024, Marcus Johansson                                  ${Purple}#
+# ${IWhite}Copyright (c) 2024-present, Marcus Johansson                          ${Purple}#
 # ${White}https://github.com/UnconnectedBedna/shrink-backup                     ${Purple}#
 # ${White}All rights reserved.                                                  ${Purple}#
 #                                                                       #
@@ -315,7 +315,7 @@ EOM
 # Parse command-line options
 options=$(getopt -o Uatyelzhq --long help,version,quiet,fix,f2fs,no-color,rsync,loop,chroot: -- "$@")
 [ $? -eq 0 ] || {
-    echo -e "${Red}Incorrect options provided"
+    echo -e "${Red}Invalid options provided"
     help
 }
 eval set -- "$options"
@@ -346,6 +346,7 @@ done
 while [ "$#" -gt 0 ]; do
   if [[ "$1" =~ ^- ]]; then
     shift
+  # If --loop or --chroot is used, IMG_FILE is already set
   elif [ -n "$IMG_FILE" ]; then
     ADDED_SPACE="$2"
     break

--- a/shrink-backup
+++ b/shrink-backup
@@ -2416,12 +2416,13 @@ if grep -q 'boot' /etc/fstab; then
           read -r -p '## Do you want to mount boot partition? [y/n] ' input
         fi
         case $input in
-          [Yy]) debug 'DEBUG' "Y or y pressed to confirm, running: mount ${fstab[0]} ${fstab[1]}"; mount "${fstab[0]}" "${fstab[1]}"; break;;
+          [Yy]) debug 'DEBUG' "Y or y pressed to confirm, running: mount ${fstab[0]} ${fstab[1]}"; echo -e "${Yellow}!! Mounting boot partition to ${fstab[1]}..."; mount "${fstab[0]}" "${fstab[1]}"; break;;
           [Nn]) echo -e "${Red}!! Aborting..."; exit 4;;
           *) echo -e "${Yellow}!! ${Red}ERROR! ${Yellow}Please enter ${Green}'y' ${Yellow}or ${Green}'n'${Yellow}"; debug 'WARNING' "ERROR, please enter 'y' or 'n'";;
         esac
       done
     else
+      echo -e "${Yellow}!! Mounting boot partition to ${fstab[1]}..."
       debug 'DEBUG' "Running: mount ${fstab[0]} ${fstab[1]}"
       mount "${fstab[0]}" "${fstab[1]}"
     fi

--- a/shrink-backup
+++ b/shrink-backup
@@ -39,19 +39,17 @@ function cleanup() {
   # exit 1 = early/clean error
   # exit 2 = help, version & looprun
   # exit 3 = later/normal error
-  # exit 4 = abort early
-  # exit 5 = abort later
-  # exit 6 = rsync error
+  # exit 4 = aborted by user
+  # exit 5 = rsync error
   # exit 10 = stopped by user (ctrl+c)
   local exit_code="$?"
 
   if [ "$exit_code" -ne 1 ] && [ "$exit_code" -ne 2 ]; then
     case $exit_code in
       0) debug 'DEBUG' 'Cleanup function called with exit 0';;
-      4) debug 'WARNING' 'Script aborted by user early, cleanup exit 4';;
-      5) debug 'WARNING' 'Script aborted by user later, cleanup exit 5';;
-      6) debug 'ERROR' 'Script failed during rsync, cleanup exit 6';;
-      10) echo -e "\n${Yellow}!! Script stopped by user..."; debug 'WARNING' 'Script stopped by user with ctrl+c, cleanup exit 10';;
+      4) debug 'WARNING' 'Script aborted by user, cleanup exit 4';;
+      5) debug 'ERROR' 'Script failed during rsync, cleanup exit 5';;
+      10) echo -e "\n${Yellow}!! Script aborted by user with ctrl+c..."; debug 'WARNING' 'Script stopped by user with ctrl+c, cleanup exit 10';;
       *) echo -e "${Yellow}!! Cleanup function called with non-zero exit code, something went wrong!!!"; debug 'ERROR' "Cleanup function called with non zero exit code: exit $exit_code";;
     esac
 
@@ -1093,7 +1091,7 @@ function do_mount() {
         fi
         case $input in
           [Yy]) debug 'DEBUG' "Y or y pressed to confirm, running: mount $LOCAL_DEV_BOOT_PATH $BOOT_PATH"; mount "$LOCAL_DEV_BOOT_PATH" "$BOOT_PATH"; break;;
-          [Nn]) echo -e "${Red}!! Aborting..."; exit 3;;
+          [Nn]) echo -e "${Red}!! Aborting..."; exit 4;;
           *) echo -e "${Yellow}!! ${Red}ERROR! ${Yellow}Please enter ${Green}'y' ${Yellow}or ${Green}'n'${Yellow}"; debug 'WARNING' "ERROR, please enter 'y' or 'n'";;
         esac
       done
@@ -1366,7 +1364,7 @@ function do_rsync() {
     echo -e "${Yellow}$output\n${Red}!! RSYNC FAILED!!!"
     debug 'BREAK'
     debug 'ERROR' "RSYNC FAILED:\nPIPESTATUS=${PIPESTATUS[0]}\n$output\n-------------------------------------------------------------------------------------"
-    exit 6
+    exit 5
   elif [ "${PIPESTATUS[0]}" -eq 23 ]; then
     echo -e "${White}## ${Yellow}Warning, rsync code 23, some files vanished before they could be transferred (code 24) at main.c"
     echo -e "${White}## ${Yellow}This does NOT mean the backup failed"

--- a/shrink-backup
+++ b/shrink-backup
@@ -443,8 +443,8 @@ function chrootrun() {
       (( count -- ))
       debug 'INFO' 'Boot partition found in fstab, mounting boot partition'
       fstab=($(cat "$TMP_DIR"/etc/fstab | grep 'boot'))
-      BOOT_PATH="${fstab[1]}" # Used to find mount in cleanup function
-      debug 'DEBUG' "BOOT_PATH=$BOOT_PATH"
+#       BOOT_PATH="${fstab[1]}" # Used to find mount in cleanup function
+#       debug 'DEBUG' "BOOT_PATH=$BOOT_PATH"
       echo -e "${White}## ${IWhite}Mounting ${Green}${fstab[1]} ${IWhite}from fstab"
       $SLEEPING
       debug 'DEBUG' "Running: mount -o ${fstab[3]} ${LSBLK_PARTITIONS[$count]} ${TMP_DIR}${fstab[1]}"
@@ -483,9 +483,9 @@ function chrootrun() {
     fi
     # Assumes boot exists and is on first partition
     fstab=($(cat "$TMP_DIR"/etc/fstab | grep 'boot'))
-    BOOT_PATH="${fstab[1]}" # Used to find mount in cleanup function
+#     BOOT_PATH="${fstab[1]}" # Used to find mount in cleanup function
+#     debug 'DEBUG' "BOOT_PATH=$BOOT_PATH"
     debug 'INFO' 'Mounting boot partition'
-    debug 'DEBUG' "BOOT_PATH=$BOOT_PATH"
     echo -e "${White}## ${IWhite}Mounting ${Green}${fstab[1]} ${IWhite}from fstab"
     $SLEEPING
     debug 'DEBUG' "Running: mount -o ${fstab[3]} ${LSBLK_PARTITIONS[1]} ${TMP_DIR}${fstab[1]}"
@@ -548,7 +548,7 @@ function dev_variables() {
 
   # Check if separate boot and root partition exists and set variables accordingly
   if grep -q 'boot' /etc/fstab; then
-    debug 'INFO' 'Separate boot partition detected'
+#     debug 'INFO' 'Separate boot partition detected'
     BOOT_PARTITION=true
     LOCAL_DEV_BOOT_PATH=$(mount --fake | grep 'boot' | awk '{print $1}')
     LOCAL_DEV_ROOT_PATH=$(mount --fake | grep ' / ' | awk '{print $1}')
@@ -557,8 +557,8 @@ function dev_variables() {
     LOCAL_ROOT_UUID=$(lsblk -no uuid "$LOCAL_DEV_ROOT_PATH")
     LOCAL_ROOT_PARTUUID=$(lsblk -no partuuid "$LOCAL_DEV_ROOT_PATH")
     debug 'DEBUG' "LOCAL_BOOT_UUID=$LOCAL_BOOT_UUID | LOCAL_ROOT_UUID=$LOCAL_ROOT_UUID | LOCAL_ROOT_PARTUUID=$LOCAL_ROOT_PARTUUID"
-    BOOT_PATH=$(cat /etc/fstab | grep 'boot' | awk '{print $2}')
-    debug 'DEBUG' "BOOT_PATH=$BOOT_PATH"
+#     BOOT_PATH=$(cat /etc/fstab | grep 'boot' | awk '{print $2}')
+#     debug 'DEBUG' "BOOT_PATH=$BOOT_PATH"
   else
     debug 'INFO' 'No boot partition detected'
     BOOT_PARTITION=false
@@ -1079,24 +1079,24 @@ function do_mount() {
 
   # Mount boot partition if exists
   if [ -n "$BOOT_PATH" ]; then
-    if ! mount --fake | grep -q 'boot'; then
-      while true; do
-        if [ "$COLORS" = true ]; then
-          echo -e "${Red}!! Boot found in fstab but partition not mounted..."
-          debug 'WARNING' 'Boot found in fstab but partition not mounted'
-          debug 'INFO' 'Do you want to mount boot partition?'
-          read -r -p $'\e[0;37m## \e[0;97mDo you want to mount boot partition? \e[0;92m[y/n] \e[0m' input
-        else
-          read -r -p '## Do you want to mount boot partition? [y/n] ' input
-        fi
-        case $input in
-          [Yy]) debug 'DEBUG' "Y or y pressed to confirm, running: mount $LOCAL_DEV_BOOT_PATH $BOOT_PATH"; mount "$LOCAL_DEV_BOOT_PATH" "$BOOT_PATH"; break;;
-          [Nn]) echo -e "${Red}!! Aborting..."; exit 4;;
-          *) echo -e "${Yellow}!! ${Red}ERROR! ${Yellow}Please enter ${Green}'y' ${Yellow}or ${Green}'n'${Yellow}"; debug 'WARNING' "ERROR, please enter 'y' or 'n'";;
-        esac
-      done
-    sleep 1
-    fi
+#     if ! mount --fake | grep -q 'boot'; then
+#       while true; do
+#         if [ "$COLORS" = true ]; then
+#           echo -e "${Red}!! Boot found in fstab but partition not mounted..."
+#           debug 'WARNING' 'Boot found in fstab but partition not mounted'
+#           debug 'INFO' 'Do you want to mount boot partition?'
+#           read -r -p $'\e[0;37m## \e[0;97mDo you want to mount boot partition? \e[0;92m[y/n] \e[0m' input
+#         else
+#           read -r -p '## Do you want to mount boot partition? [y/n] ' input
+#         fi
+#         case $input in
+#           [Yy]) debug 'DEBUG' "Y or y pressed to confirm, running: mount $LOCAL_DEV_BOOT_PATH $BOOT_PATH"; mount "$LOCAL_DEV_BOOT_PATH" "$BOOT_PATH"; break;;
+#           [Nn]) echo -e "${Red}!! Aborting..."; exit 4;;
+#           *) echo -e "${Yellow}!! ${Red}ERROR! ${Yellow}Please enter ${Green}'y' ${Yellow}or ${Green}'n'${Yellow}"; debug 'WARNING' "ERROR, please enter 'y' or 'n'";;
+#         esac
+#       done
+#     sleep 1
+#     fi
     echo -e "${White}## ${IWhite}Mounting img boot partition..."
     $SLEEPING
     debug 'INFO' 'Mounting boot inside root'
@@ -2397,6 +2397,38 @@ if ! [[ "$ADDED_SPACE" =~ $RE ]]; then
   typeset -i ADDED_SPACE
 fi
 
+# If boot exists in fstab, set BOOT_PATH and make sure boot is mounted
+if grep -q 'boot' /etc/fstab; then
+  debug 'INFO' 'Separate boot partition detected'
+  BOOT_PATH=$(cat /etc/fstab | grep 'boot' | awk '{print $2}') # Used in cleanup function
+  debug 'DEBUG' "BOOT_PATH=$BOOT_PATH"
+  if ! mount --fake | grep -q 'boot'; then
+    echo -e "${Red}!! Boot found in fstab but partition not mounted..."
+    debug 'WARNING' 'Boot found in fstab but partition not mounted'
+    $SLEEPING
+    fstab=($(cat /etc/fstab | grep 'boot'))
+    if [ "$PROMPTS" = true ]; then
+      while true; do
+        if [ "$COLORS" = true ]; then
+          debug 'INFO' 'Do you want to mount boot partition?'
+          read -r -p $'\e[0;37m## \e[0;97mDo you want to mount boot partition? \e[0;92m[y/n] \e[0m' input
+        else
+          read -r -p '## Do you want to mount boot partition? [y/n] ' input
+        fi
+        case $input in
+          [Yy]) debug 'DEBUG' "Y or y pressed to confirm, running: mount ${fstab[0]} ${fstab[1]}"; mount "${fstab[0]}" "${fstab[1]}"; break;;
+          [Nn]) echo -e "${Red}!! Aborting..."; exit 4;;
+          *) echo -e "${Yellow}!! ${Red}ERROR! ${Yellow}Please enter ${Green}'y' ${Yellow}or ${Green}'n'${Yellow}"; debug 'WARNING' "ERROR, please enter 'y' or 'n'";;
+        esac
+      done
+    else
+      debug 'DEBUG' "Running: mount ${fstab[0]} ${fstab[1]}"
+      mount "${fstab[0]}" "${fstab[1]}"
+    fi
+  sleep 1
+  fi
+fi
+
 # If --loop is requested, execute looprun function. Will exit script within the function
 if [ "$LOOPRUN" = true ]; then
   debug 'INFO' 'Running function: looprun'
@@ -2410,13 +2442,6 @@ if [ "$CHROOTRUN" = true ]; then
 fi
 
 echo -e "${White}## ${IWhite}Scanning filesystem and calculating..."
-
-# Make sure boot is mounted if it exists in fstab
-if grep -q 'boot' /etc/fstab && ! mount --fake | grep -q 'boot'; then
-  echo -e "${Red}!! Boot found in fstab but partition not mounted, please mount and retry script!!!"
-  debug 'ERROR' 'Boot found in fstab but partition not mounted, exit 1'
-  exit 1
-fi
 
 # Check what filesystem root is using and set LOCAL_DEV_PATH & PARTITION_TABLE
 FSTYPE="$(mount --fake | grep ' / ' | awk '{print $5}')"

--- a/shrink-backup
+++ b/shrink-backup
@@ -25,8 +25,10 @@ function debug() {
         echo -e "$(date +"%Y-%m-%d %H:%M:%S") [$log_level]    - $log_message" >> "$LOG_FILE"
       elif [ $log_level = 'ERROR' ]; then
         echo -e "$(date +"%Y-%m-%d %H:%M:%S") [$log_level]   - $log_message" >> "$LOG_FILE"
-      else
+      elif [ $log_level = 'WARNING' ]; then
         echo -e "$(date +"%Y-%m-%d %H:%M:%S") [$log_level] - $log_message" >> "$LOG_FILE"
+      else
+        echo -e "$(date +"%Y-%m-%d %H:%M:%S") [$log_level]   - $log_message" >> "$LOG_FILE"
       fi
     fi
   fi
@@ -67,46 +69,69 @@ function cleanup() {
     if [ -n "$BOOT_PATH" ] && [ -n "$TMP_DIR" ] && grep -qs "${TMP_DIR}${BOOT_PATH} " /proc/mounts; then
       # Loop until the mount point is not busy
       while true; do
-        # Check if the mount point is still busy
-        if ! umount "${TMP_DIR}${BOOT_PATH}" && [ -n "$BOOT_PATH" ] && [ -n "$TMP_DIR" ] && grep -qs "${TMP_DIR}${BOOT_PATH} " /proc/mounts; then
+        # Check if the mount point is busy
+        if ! umount "${TMP_DIR}${BOOT_PATH}" && grep -qs "${TMP_DIR}${BOOT_PATH} " /proc/mounts; then
           # If it is, sleep for 5 seconds and try again
           echo -e "${Yellow}!! ${Green}${TMP_DIR}${BOOT_PATH} ${Yellow}is busy, retrying in 5 seconds..."
           debug 'DEBUG' "${TMP_DIR}${BOOT_PATH} is busy, retrying in 5 seconds"
           sleep 5
         else
-          # If it's not busy, provide debug info
           debug 'DEBUG' "Unmounting boot partition in cleanup function: umount ${TMP_DIR}${BOOT_PATH}"
           break
         fi
       done
     fi
 
-    # Unmount img home (only relevant for btrfs)
-    if [ -n "$TMP_DIR" ] && grep -qs "${TMP_DIR}/home " /proc/mounts; then
-      while true; do
-        if ! umount "${TMP_DIR}/home" && [ -n "$TMP_DIR" ] && grep -qs "${TMP_DIR}/home " /proc/mounts; then
-          echo -e "${Yellow}!! ${Green}${TMP_DIR}/home ${Yellow}is busy, retrying in 5 seconds..."
-          debug 'DEBUG' "${TMP_DIR}/home is busy, retrying in 5 seconds"
-          sleep 5
-        else
-          debug 'DEBUG' "Unmounting home partition in cleanup function: umount ${TMP_DIR}/home"
-          break
+    # btrfs
+    if [ "$FSTYPE" == 'btrfs' ]; then
+      # Non-root subvolumes
+      for subvol in "${LOCAL_TOP_SUBVOLUMES[@]}"; do
+        if grep -q "$subvol" /etc/fstab && [[ "$subvol" != '@' ]]; then
+          path=$(cat /etc/fstab | grep "$subvol" | awk '{print $2}')
+          if [ -n "$TMP_DIR" ] && grep -qs "${TMP_DIR}${path} " /proc/mounts; then
+            while true; do
+              if ! umount "${TMP_DIR}${path}" && grep -qs "${TMP_DIR}${path} " /proc/mounts; then
+                echo -e "${Yellow}!! ${Green}${TMP_DIR}${path} ${Yellow}is busy, retrying in 5 seconds..."
+                debug 'DEBUG' "${TMP_DIR}${path} is busy, retrying in 5 seconds"
+                sleep 5
+              else
+                debug 'DEBUG' "Unmounting subvolume $subvol in cleanup function: umount ${TMP_DIR}${path}"
+                break
+              fi
+            done
+          fi
         fi
       done
-    fi
 
-    # Unmount img root
-    if [ -n "$TMP_DIR" ] && grep -qs "$TMP_DIR " /proc/mounts; then
-      while true; do
-        if ! umount "${TMP_DIR}" && [ -n "$TMP_DIR" ] && grep -qs "$TMP_DIR " /proc/mounts; then
-          echo -e "${Yellow}!! ${Green}${TMP_DIR} ${Yellow}is busy, retrying in 5 seconds..."
-          debug 'DEBUG' "${TMP_DIR} is busy, retrying in 5 seconds"
-          sleep 5
-        else
-          debug 'DEBUG' "Unmounting root partition in cleanup function: umount ${TMP_DIR}"
-          break
-        fi
-      done
+      # Root subvolume
+      if [ -n "$TMP_DIR" ] && grep -qs "${TMP_DIR} " /proc/mounts; then
+        while true; do
+          if ! umount "${TMP_DIR}" && grep -qs "${TMP_DIR} " /proc/mounts; then
+            echo -e "${Yellow}!! ${Green}${TMP_DIR} ${Yellow}is busy, retrying in 5 seconds..."
+            debug 'DEBUG' "${TMP_DIR} is busy, retrying in 5 seconds"
+            sleep 5
+          else
+            debug 'DEBUG' "Unmounting root subvolume (@) in cleanup function: umount ${TMP_DIR}"
+            break
+          fi
+        done
+      fi
+
+    # All other filesystems
+    else
+      # Unmount img root
+      if [ -n "$TMP_DIR" ] && grep -qs "$TMP_DIR " /proc/mounts; then
+        while true; do
+          if ! umount "${TMP_DIR}" && grep -qs "$TMP_DIR " /proc/mounts; then
+            echo -e "${Yellow}!! ${Green}${TMP_DIR} ${Yellow}is busy, retrying in 5 seconds..."
+            debug 'DEBUG' "${TMP_DIR} is busy, retrying in 5 seconds"
+            sleep 5
+          else
+            debug 'DEBUG' "Unmounting root partition in cleanup function: umount ${TMP_DIR}"
+            break
+          fi
+        done
+      fi
     fi
 
     # Remove loop
@@ -482,6 +507,7 @@ function chrootrun() {
       debug 'ERROR' "IMG ROOT SUBVOLUME (@) MOUNT FAILED:\n$output\n-------------------------------------------------------------------------------------"
       exit 3
     fi
+
     # Remount with flags from fstab
     fstab=($(cat "$TMP_DIR"/etc/fstab | grep ' / '))
     echo -e "${White}## ${IWhite}Remounting img ${Green}@ ${IWhite}subvolume with flags from fstab"
@@ -494,6 +520,7 @@ function chrootrun() {
       debug 'ERROR' "REMOUNTING IMG ROOT SUBVOLUME (@) FAILED:\n$output\n-------------------------------------------------------------------------------------"
       exit 3
     fi
+
     # Assumes boot exists and is on first partition
     fstab=($(cat "$TMP_DIR"/etc/fstab | grep 'boot'))
     debug 'INFO' 'Mounting img boot partition'
@@ -506,6 +533,7 @@ function chrootrun() {
       debug 'ERROR' "IMG BOOT MOUNT FAILED:\n$output\n-------------------------------------------------------------------------------------"
       exit 3
     fi
+
     # Filter out @ and subvolumes not in fstab
     IMG_SUBVOLUMES=($(btrfs subvol list $TMP_DIR | awk '{print $9}'))
     echo -e "${White}## ${IWhite}Subvolumes found on img ${Green}${IMG_SUBVOLUMES[@]}"
@@ -670,19 +698,48 @@ function btrfs_variables() {
     LOCAL_AUTORESIZE_MIN=$(( LOCAL_USED_SPACE + 536870912 ))
     debug 'DEBUG' "LOCAL_AUTORESIZE_MIN=$LOCAL_AUTORESIZE_MIN bytes"
   fi
-  debug 'DEBUG' "Running: btrfs subvolume list / | awk '{print \$9}'"
-  declare -ag LOCAL_SUBVOLUMES=( $(btrfs subvolume list / | awk '{print $9}') ) # -g = make variable global
-  debug 'DEBUG' "LOCAL_SUBVOLUMES=$(echo ${LOCAL_SUBVOLUMES[@]})"
+
+  # Get subvolumes
+  debug 'DEBUG' "Running: btrfs subvolume list / | grep ' 5 ' | awk '{print \$9}'"
+  declare -ag LOCAL_TOP_SUBVOLUMES=( $(btrfs subvolume list / | grep ' 5 ' | awk '{print $9}') ) # -g = make variable global
+  debug 'DEBUG' "LOCAL_TOP_SUBVOLUMES=$(echo ${LOCAL_TOP_SUBVOLUMES[@]})"
+  debug 'DEBUG' "Running: btrfs subvolume list / --sort=path | grep -v ' 5 ' | awk '{print \$9}'"
+  declare -ag LOCAL_NESTED_SUBVOLUMES=( $(btrfs subvolume list / --sort=path | grep -v ' 5 ' | awk '{print $9}') )
+  debug 'DEBUG' "LOCAL_NESTED_SUBVOLUMES=$(echo ${LOCAL_NESTED_SUBVOLUMES[@]})"
+
   if [ "$EXCLUDE_FILE" = true ]; then
-    debug 'INFO' 'Filtering out volumes to exclude from exclude.txt or shrink-backup.conf'
-    for i in ${!LOCAL_SUBVOLUMES[@]}; do
-      subvol=${LOCAL_SUBVOLUMES[i]}
-      if $(echo $subvol | grep -q -f "$EXCLUDE_FILE_LOCATION"); then
+    # Filter out top subvolumes not in fstab
+    debug 'INFO' 'Filtering out top level 5 subvolumes not existing in fstab'
+    for i in ${!LOCAL_TOP_SUBVOLUMES[@]}; do
+      subvol=${LOCAL_TOP_SUBVOLUMES[i]}
+      if $(echo $subvol | grep -q -v -f /etc/fstab); then
         debug 'DEBUG' "Filtering out subvolume: $subvol"
-        unset LOCAL_SUBVOLUMES[i]
+        unset LOCAL_TOP_SUBVOLUMES[i]
       fi
     done
-    debug 'DEBUG' "After filtering: LOCAL_SUBVOLUMES=$(echo ${LOCAL_SUBVOLUMES[@]})"
+    debug 'DEBUG' "After filtering: LOCAL_TOP_SUBVOLUMES=$(echo ${LOCAL_TOP_SUBVOLUMES[@]})"
+
+    # Filter out top subvolumes from exclude.txt or shrink-backup.conf
+    debug 'INFO' 'Filtering out top level 5 subvolumes to exclude from exclude.txt or shrink-backup.conf'
+    for i in ${!LOCAL_TOP_SUBVOLUMES[@]}; do
+      subvol=${LOCAL_TOP_SUBVOLUMES[i]}
+      if $(echo $subvol | grep -q -f "$EXCLUDE_FILE_LOCATION"); then
+        debug 'DEBUG' "Filtering out subvolume: $subvol"
+        unset LOCAL_TOP_SUBVOLUMES[i]
+      fi
+    done
+    debug 'DEBUG' "After filtering: LOCAL_TOP_SUBVOLUMES=$(echo ${LOCAL_TOP_SUBVOLUMES[@]})"
+
+    # Filter out nested subvolumes from exclude.txt or shrink-backup.conf
+    debug 'INFO' 'Filtering out nested subvolumes to exclude from exclude.txt or shrink-backup.conf'
+    for i in ${!LOCAL_NESTED_SUBVOLUMES[@]}; do
+      subvol=${LOCAL_NESTED_SUBVOLUMES[i]}
+      if $(echo $subvol | grep -q -f "$EXCLUDE_FILE_LOCATION"); then
+        debug 'DEBUG' "Filtering out subvolume: $subvol"
+        unset LOCAL_NESTED_SUBVOLUMES[i]
+      fi
+    done
+    debug 'DEBUG' "After filtering: LOCAL_NESTED_SUBVOLUMES=$(echo ${LOCAL_NESTED_SUBVOLUMES[@]})"
   fi
 return 0
 }
@@ -770,37 +827,6 @@ function img_variables() {
       exit 3
     fi
   fi
-
-  # Check for btrfs subvolumes on img
-  # None of this is needed unless creation of new voumes during update will be implemented
-#   if [ "$FSTYPE" == 'btrfs' ] && [ "$UPDATE" = true ]; then
-#     # Check for temp directory and create if needed
-#     if ! [ -d "$TMP_DIR" ]; then
-#       echo -e "${White}## ${IWhite}Creating temp directory..."
-#       $SLEEPING
-#       debug 'INFO' 'Creating temp directory'
-#       debug 'DEBUG' "Running: mktemp -d -t backup-XXX"
-#       TMP_DIR=$(mktemp -d -t backup-XXX)
-#       debug 'DEBUG' "TMP_DIR=$TMP_DIR"
-#     fi
-#     $SLEEPING
-#     partprobe "$LOOP"
-#     fstab=($(cat /etc/fstab | grep ' / '))
-#     debug 'INFO' 'Mounting btrfs filesystem to find subvolumes'
-#     debug 'DEBUG' "Running: mount -o ${fstab[3]} $IMG_DEV_ROOT_PATH $TMP_DIR"
-#     if ! output=$(mount -o "${fstab[3]}" "$IMG_DEV_ROOT_PATH" "$TMP_DIR" 2>&1); then
-#       echo -e "${Yellow}$output\n${Red}!! ROOT MOUNT FAILED!!!"
-#       debug 'BREAK'
-#       debug 'ERROR' "ROOT MOUNT FAILED:\n$output\n-------------------------------------------------------------------------------------"
-#       exit 3
-#     fi
-#     $SLEEPING
-#     debug 'DEBUG' "Running: btrfs subvolume list $TMP_DIR | awk '{print \$9}'"
-#     declare -a IMG_SUBVOLUMES=( $(btrfs subvolume list "$TMP_DIR" | awk '{print $9}') )
-#     debug 'DEBUG' "IMG_SUBVOLUMES=$(echo ${IMG_SUBVOLUMES[@]})"
-#     debug 'DEBUG' "Running: umount $TMP_DIR"
-#     umount "$TMP_DIR"
-#   fi
 return 0
 }
 
@@ -1039,7 +1065,6 @@ function do_mount() {
     TMP_DIR=$(mktemp -d -t backup-XXX)
     debug 'DEBUG' "TMP_DIR=$TMP_DIR"
   fi
-  $SLEEPING
   partprobe "$LOOP"
 
   # ext4 & f2fs
@@ -1059,6 +1084,8 @@ function do_mount() {
   elif [ "$FSTYPE" == 'btrfs' ]; then
     declare -a fstab=( $(cat /etc/fstab | grep ' / ') )
     echo -e "${White}## ${IWhite}Mounting root (${Green}@${IWhite}) subvolume..."
+    $SLEEPING
+    debug 'INFO' 'Mounting root (@) subvolume from loop'
     debug 'DEBUG' "Running: mount -o ${fstab[3]} $IMG_DEV_ROOT_PATH $TMP_DIR"
     if ! output=$(mount -o "${fstab[3]}" "$IMG_DEV_ROOT_PATH" "$TMP_DIR" 2>&1); then
       echo -e "${Yellow}$output\n${Red}!! ROOT SUBVOLUME MOUNT FAILED!!!"
@@ -1066,14 +1093,18 @@ function do_mount() {
       debug 'ERROR' "ROOT SUBVOLUME MOUNT FAILED:\n$output\n-------------------------------------------------------------------------------------"
       exit 3
     fi
-    $SLEEPING
 
-    # New volumes will not be created during an update
-    for subvol in "${LOCAL_SUBVOLUMES[@]}"; do
-      # Excluding root (@) subvolume and mounting all else in fstab, nested volumes are not in fstab
+    # Mount top subvolums (except @). New top volumes will not be created during an update, if new top volumes have been created on device script will exit
+    for subvol in "${LOCAL_TOP_SUBVOLUMES[@]}"; do
+      # Excluding root (@) subvolume and mounting all else in fstab
       if grep -q "$subvol" /etc/fstab && [[ "$subvol" != '@' ]]; then
         declare -a fstab=( $(cat /etc/fstab | grep "$subvol") )
         echo -e "${White}## ${IWhite}Mounting subvolume: ${Green}$subvol"
+        $SLEEPING
+        if ! [ -d "${TMP_DIR}${fstab[1]}" ]; then
+          debug 'DEBUG' "Directory for subvol $subvol did not exist, running: mkdir -p ${TMP_DIR}${fstab[1]}"
+          mkdir -p ${TMP_DIR}${fstab[1]}
+        fi
         debug 'DEBUG' "Running: mount -o ${fstab[3]} $IMG_DEV_ROOT_PATH ${TMP_DIR}${fstab[1]}"
         if ! output=$(mount -o "${fstab[3]}" "$IMG_DEV_ROOT_PATH" "${TMP_DIR}${fstab[1]}" 2>&1); then
           echo -e "${Yellow}$output\n${Red}!! SUBVOLUME MOUNT FAILED!!!"
@@ -1081,16 +1112,75 @@ function do_mount() {
           debug 'ERROR' "SUBVOLUME MOUNT FAILED:\n$output\n-------------------------------------------------------------------------------------"
           exit 3
         fi
-
-      # Make sure directories exist for nested volumes
-      elif [[ "$subvol_path" != '@'* ]]; then
-        if ! [ -d "${TMP_DIR}/${subvol_path}" ]; then
-          debug 'DEBUG' "Running: mkdir -p ${TMP_DIR}/${subvol_path}"
-          mkdir -p "${TMP_DIR}/${subvol_path}"
-        fi
       fi
-      $SLEEPING
     done
+
+    # Check for differences in nested subvolumes & create/remove if necessary
+    if [[ $(echo $(btrfs subvolume list "$TMP_DIR" --sort=path | grep -v ' 5 ' | awk '{print $9}') ) != "${LOCAL_NESTED_SUBVOLUMES[@]}" ]]; then
+      echo -e "${White}## ${IWhite}Managing nested subvolumes..."
+      $SLEEPING
+      IMG_NESTED_SUBVOLUMES=( $(btrfs subvolume list "$TMP_DIR" --sort=path | grep -v ' 5 ' | awk '{print $9}') )
+      debug 'DEBUG' "IMG_NESTED_SUBVOLUMES=$(echo ${IMG_NESTED_SUBVOLUMES[@]})"
+
+      # Create new nested subvolume(s)
+      for subvol in ${LOCAL_NESTED_SUBVOLUMES[@]}; do
+        if ! echo "${IMG_NESTED_SUBVOLUMES[@]}" | grep -q "$subvol"; then
+          echo -e "${White}## ${IWhite}Creating nested subvolume: ${Green}$subvol"
+          $SLEEPING
+          # Fix path if nested subvolume is in other location than root subvolume
+          top_subvols="$(echo ${LOCAL_TOP_SUBVOLUMES[@]} | sed 's/ /|/g')" # convert spaces into |
+          if echo "$subvol" | grep -E "$top_subvols"; then
+            debug 'INFO' 'Nested volume not under root, fixing path'
+            for top_subvol in ${LOCAL_TOP_SUBVOLUMES[@]}; do
+              if echo "$subvol" | grep -qw "$top_subvol"; then
+                break
+              fi
+            done
+            path="$(cat /etc/fstab | grep $top_subvol | awk '{print $2}' | sed 's/^\///')" # remove first slash
+            subvol="$(echo $subvol | sed "s|$top_subvol|$path|g")"
+          fi
+          # Remove directory if existing
+          if [ -d "${TMP_DIR}/${subvol}" ]; then
+            debug 'DEBUG' "Directory for nested volume exists, deleting: rm -rf ${TMP_DIR}/${subvol}"
+            rm -rf "${TMP_DIR}/${subvol}"
+          fi
+          debug 'DEBUG' "Running: btrfs subvolume create ${TMP_DIR}/$subvol"
+          if ! output=$(btrfs subvolume create -p "$TMP_DIR"/"$subvol" 2>&1); then
+            echo -e "${Yellow}$output\n${Red}!! CREATE NESTED SUBVOLUME FAILED!!!"
+            debug 'BREAK'
+            debug 'ERROR' "CREATE NESTED SUBVOLUME FAILED:\n$output\n-------------------------------------------------------------------------------------"
+            exit 3
+          fi
+        fi
+      done
+
+      # Delete nested img subvolume(s)
+      for subvol in ${IMG_NESTED_SUBVOLUMES[@]}; do
+        if ! echo "${LOCAL_NESTED_SUBVOLUMES[@]}" | grep -q "$subvol"; then
+          echo -e "${White}## ${IWhite}Deleting nested subvolume: ${Green}$subvol"
+          $SLEEPING
+          # Fix path if nested subvolume is in other location than root subvolume
+          top_subvols="$(echo ${LOCAL_TOP_SUBVOLUMES[@]} | sed 's/ /|/g')" # convert spaces into |
+          if echo "$subvol" | grep -qE "$top_subvols"; then
+            debug 'INFO' 'Nested volume not under root, fixing path'
+            for top_subvol in ${LOCAL_TOP_SUBVOLUMES[@]}; do
+              if echo "$subvol" | grep -qw "$top_subvol"; then
+                break
+              fi
+            done
+            path="$(cat /etc/fstab | grep $top_subvol | awk '{print $2}' | sed 's/^\///')" # remove first slash
+            subvol="$(echo $subvol | sed "s|$top_subvol|$path|g")"
+          fi
+          debug 'DEBUG' "Running: btrfs subvolume delete ${TMP_DIR}/$subvol"
+          if ! output=$(btrfs subvolume delete "$TMP_DIR"/"$subvol" 2>&1); then
+            echo -e "${Yellow}$output\n${Red}!! DELETE NESTED SUBVOLUME FAILED!!!"
+            debug 'BREAK'
+            debug 'ERROR' "DELETE NESTED SUBVOLUME FAILED:\n$output\n-------------------------------------------------------------------------------------"
+            exit 3
+          fi
+        fi
+      done
+    fi
   fi
 
   # Mount boot partition if exists
@@ -1151,8 +1241,8 @@ function do_e2fsck() {
       do_mount
     fi
 
+  # Normal check
   else
-    # Normal check
     echo -e "${White}## ${IWhite}Checking img filesystem..."
     $SLEEPING
 
@@ -1161,7 +1251,6 @@ function do_e2fsck() {
     debug 'DEBUG' "Running: e2fsck -p -f $IMG_DEV_ROOT_PATH\n$output\n-------------------------------------------------------------------------------------"
     $SLEEPING
   fi
-
 return 0
 }
 
@@ -1190,8 +1279,10 @@ function do_resize() {
   debug 'DEBUG' "IMG_ROOT_PARTN=$IMG_ROOT_PARTN"
 
   # Check img filesystem
-  debug 'INFO' 'Running function: do_e2fsck'
-  do_e2fsck
+  if [ $FSTYPE == 'ext4' ]; then
+    debug 'INFO' 'Running function: do_e2fsck'
+    do_e2fsck
+  fi
 
 
   # Expanding
@@ -1267,8 +1358,10 @@ function do_resize() {
     debug 'DEBUG' "$output\n-------------------------------------------------------------------------------------"
 
     # Check img filesystem
-    debug 'INFO' 'Running function: do_e2fsck'
-    do_e2fsck
+    if [ $FSTYPE == 'ext4' ]; then
+      debug 'INFO' 'Running function: do_e2fsck'
+      do_e2fsck
+    fi
 
 
   # Shrinking
@@ -1313,12 +1406,6 @@ function do_resize() {
       debug 'ERROR' "TRUNCATE FAILED:\n$output\n-------------------------------------------------------------------------------------"
       exit 3
     fi
-
-    # Final check of img filesystem
-    debug 'INFO' 'Finalizing filesystem'
-    debug 'DEBUG' "Running do_e2fsck 'final'"
-    do_e2fsck 'final'
-
   fi
 return 0
 }
@@ -1471,8 +1558,10 @@ function make_img() {
   echo -e "# ${Green}$IMG_FILE ${Purple}$(printf "%+$(( COLS - 2 - $(echo ${IMG_FILE} | wc -m ) ))s" '#')"
   echo -e "# ${Green}$FSTYPE ${IWhite}filesystem detected on root ${Purple}$(printf "%+$(( COLS - 30 - $(echo ${FSTYPE} | wc -m ) ))s" '#')"
   if [ "$FSTYPE" == 'btrfs' ]; then
-    echo -e "# ${Green}${#LOCAL_SUBVOLUMES[@]} ${IWhite}btrfs volumes will be included ${Purple}$(printf "%+$(( COLS - 33 - $(echo ${#LOCAL_SUBVOLUMES[@]} | wc -m ) ))s" '#')"
-    echo -e "${Purple}# ${IWhite}btrfs volumes: ${Green}${LOCAL_SUBVOLUMES[@]} ${Purple}$(printf "%+$(( COLS - 17 - $(echo ${LOCAL_SUBVOLUMES[@]} | wc -m ) ))s" '#')"
+    echo -e "# ${Green}${#LOCAL_TOP_SUBVOLUMES[@]} ${IWhite}btrfs top volumes will be included ${Purple}$(printf "%+$(( COLS - 37 - $(echo ${#LOCAL_TOP_SUBVOLUMES[@]} | wc -m ) ))s" '#')"
+    echo -e "${Purple}# ${IWhite}btrfs top volumes: ${Green}${LOCAL_TOP_SUBVOLUMES[@]} ${Purple}$(printf "%+$(( COLS - 21 - $(echo ${LOCAL_TOP_SUBVOLUMES[@]} | wc -m ) ))s" '#')"
+    echo -e "# ${Green}${#LOCAL_NESTED_SUBVOLUMES[@]} ${IWhite}btrfs nested volumes will be included ${Purple}$(printf "%+$(( COLS - 40 - $(echo ${#LOCAL_NESTED_SUBVOLUMES[@]} | wc -m ) ))s" '#')"
+    echo -e "${Purple}# ${IWhite}btrfs nested volumes: ${Green}${LOCAL_NESTED_SUBVOLUMES[@]} ${Purple}$(printf "%+$(( COLS - 24 - $(echo ${LOCAL_NESTED_SUBVOLUMES[@]} | wc -m ) ))s" '#')"
   elif [ "$FSTYPE" == 'f2fs' ]; then
     echo -e "# ${Yellow}Autoexpand filesystem at boot not available for ${Green}f2fs ${Purple}$(printf "%+$(( COLS - 54 ))s" '#')"
   elif [ "$F2FS_CONVERSION" = true ]; then
@@ -1744,13 +1833,13 @@ function make_img() {
     # btrfs does work with having the same UUID on 2 filesystems at the same time but the PARTUUID is the same anyway since it's transferred with dd
     if ! output=$(mkfs.btrfs -f -m single -L "$LABEL" -v "$IMG_DEV_ROOT_PATH" 2>&1 | tee "$TTY_AVAILABILITY" ); then
       echo -e "${Yellow}$output\n${Red}!! MKFS.BTRFS FAILED!!!"
+      $SLEEPING
       debug 'BREAK'
       debug 'ERROR' "MKFS.BTRFS FAILED:\n$output\n-------------------------------------------------------------------------------------"
       exit 3
     fi
     debug 'BREAK'
     debug 'DEBUG' "Running: mkfs.btrfs -f -m single -L $LABEL -v $IMG_DEV_ROOT_PATH\n$output\n-------------------------------------------------------------------------------------"
-    $SLEEPING
 
     # Check for temp directory and create if needed
     if ! [ -d "$TMP_DIR" ]; then
@@ -1764,6 +1853,7 @@ function make_img() {
 
     # Mount btrfs filesystem and create volumes
     echo -e "${White}## ${IWhite}Creating btrfs subvolumes..."
+    $SLEEPING
     debug 'INFO' 'Mounting btrfs filesystem and creating btrfs subvolumes'
     debug 'DEBUG' "Running: mount -o noatime,compress=zstd $IMG_DEV_ROOT_PATH $TMP_DIR"
     if ! output=$(mount -o noatime,compress=zstd "$IMG_DEV_ROOT_PATH" "$TMP_DIR" 2>&1); then
@@ -1772,96 +1862,24 @@ function make_img() {
       debug 'ERROR' "BTRFS FILESYSTEM MOUNT FAILED:\n$output\n-------------------------------------------------------------------------------------"
       exit 3
     fi
-    $SLEEPING
 
-    # Create top level subvolumes, assumes subvols starting with @ are level 5 volumes
-    for subvol in "${LOCAL_SUBVOLUMES[@]}"; do
-      if [[ "$subvol" == '@'* ]]; then
-        echo -e "${White}## ${IWhite}Creating subvolume: ${Green}$subvol"
-        debug 'DEBUG' "Running: btrfs subvolume create ${TMP_DIR}/${subvol}"
-        if ! output=$(btrfs subvolume create "$TMP_DIR"/"$subvol" 2>&1); then
-          echo -e "${Yellow}$output\n${Red}!! CREATE SUBVOLUME FAILED!!!"
-          debug 'BREAK'
-          debug 'ERROR' "CREATE SUBVOLUME FAILED:\n$output\n-------------------------------------------------------------------------------------"
-          exit 3
-        fi
-      fi
+    # Create top level subvolumes
+    for subvol in "${LOCAL_TOP_SUBVOLUMES[@]}"; do
+      echo -e "${White}## ${IWhite}Creating subvolume: ${Green}$subvol"
       $SLEEPING
+      debug 'DEBUG' "Running: btrfs subvolume create ${TMP_DIR}/${subvol}"
+      if ! output=$(btrfs subvolume create "$TMP_DIR"/"$subvol" 2>&1); then
+        echo -e "${Yellow}$output\n${Red}!! CREATE SUBVOLUME FAILED!!!"
+        debug 'BREAK'
+        debug 'ERROR' "CREATE SUBVOLUME FAILED:\n$output\n-------------------------------------------------------------------------------------"
+        exit 3
+      fi
     done
 
-    # Mount root (@) subvolume
-    echo -e "${White}## ${IWhite}Mounting root (${Green}@${IWhite}) subvolume..."
-    debug 'INFO' 'Unmounting btrfs filesystem & mounting root (@) subvolume'
-    debug 'DEBUG' "Running: umount $TMP_DIR"
+    # Nested volumes are created within do_mount function
+    debug 'INFO' 'Unmounting btrfs filesystem & running function: do_mount'
     umount "$TMP_DIR"
-    $SLEEPING
-    partprobe "$LOOP"
-    #fstab=( $(cat /etc/fstab | grep "${LOCAL_SUBVOLUMES[0]}") )
-    declare -a fstab=( $(cat /etc/fstab | grep ' / ') )
-    debug 'DEBUG' "Running: mount -o ${fstab[3]} $IMG_DEV_ROOT_PATH $TMP_DIR"
-    if ! output=$(mount -o "${fstab[3]}" "$IMG_DEV_ROOT_PATH" "$TMP_DIR" 2>&1); then
-      echo -e "${Yellow}$output\n${Red}!! ROOT SUBVOLUME (@) MOUNT FAILED!!!"
-      debug 'BREAK'
-      debug 'ERROR' "ROOT SUBVOLUME (@) MOUNT FAILED:\n$output\n-------------------------------------------------------------------------------------"
-      exit 3
-    fi
-    $SLEEPING
-
-    # Create nested volumes
-    echo -e "${White}## ${IWhite}Creating nested volumes if existing..."
-    debug 'INFO' 'Creating nested volumes'
-    $SLEEPING
-
-    for subvol in "${LOCAL_SUBVOLUMES[@]}"; do
-    if [[ "$subvol" != '@'* ]]; then
-        debug 'DEBUG' "Running: mkdir -p $TMP_DIR/$(dirname $subvol)"
-        mkdir -p "$TMP_DIR"/$(dirname "$subvol")
-        echo -e "${White}## ${IWhite}Creating volume: ${Green}$subvol"
-        debug 'DEBUG' "Running: btrfs subvolume create ${TMP_DIR}/$subvol"
-        if ! output=$(btrfs subvolume create "$TMP_DIR"/"$subvol" 2>&1); then
-          echo -e "${Yellow}$output\n${Red}!! CREATE VOLUME FAILED!!!"
-          debug 'BREAK'
-          debug 'ERROR' "CREATE VOLUME FAILED:\n$output\n-------------------------------------------------------------------------------------"
-          exit 3
-        fi
-      fi
-      $SLEEPING
-    done
-
-    # Mount volumes from fstab
-    echo -e "${White}## ${IWhite}Mounting img btrfs volumes from fstab..."
-    debug 'INFO' 'Mounting volumes'
-    partprobe "$LOOP"
-    $SLEEPING
-
-    for subvol in "${LOCAL_SUBVOLUMES[@]}"; do
-      # Excluding root (@) subvolume and mounting all else in fstab, nested volumes are not in fstab
-      if grep -q "$subvol" /etc/fstab && [[ "$subvol" != '@' ]]; then
-        declare -a fstab=( $(cat /etc/fstab | grep "$subvol") )
-        debug 'DEBUG' "Running: mkdir -p ${TMP_DIR}${fstab[1]}"
-        mkdir -p "${TMP_DIR}${fstab[1]}"
-        echo -e "${White}## ${IWhite}Mounting subvolume: ${Green}$subvol"
-        debug 'DEBUG' "Running: mount -o ${fstab[3]} $IMG_DEV_ROOT_PATH ${TMP_DIR}${fstab[1]}"
-        if ! output=$(mount -o "${fstab[3]}" "$IMG_DEV_ROOT_PATH" "${TMP_DIR}${fstab[1]}" 2>&1); then
-          echo -e "${Yellow}$output\n${Red}!! SUBVOLUME MOUNT FAILED!!!"
-          debug 'BREAK'
-          debug 'ERROR' "SUBVOLUME MOUNT FAILED:\n$output\n-------------------------------------------------------------------------------------"
-          exit 3
-        fi
-      fi
-      $SLEEPING
-    done
-
-    echo -e "${White}## ${IWhite}Mounting boot..."
-    debug 'DEBUG' "Running: mount $IMG_DEV_BOOT_PATH ${TMP_DIR}${BOOT_PATH}"
-    mkdir -p ${TMP_DIR}${BOOT_PATH}
-    if ! output=$(mount "$IMG_DEV_BOOT_PATH" "${TMP_DIR}${BOOT_PATH}" 2>&1); then
-      echo -e "${Yellow}$output\n${Red}!! BOOT MOUNT FAILED!!!"
-      debug 'BREAK'
-      debug 'ERROR' "BOOT MOUNT FAILED:\n$output\n-------------------------------------------------------------------------------------"
-      exit 3
-    fi
-    $SLEEPING
+    do_mount
   fi
 
   # Copy files
@@ -1947,8 +1965,10 @@ function update_img() {
   echo -e "# ${Green}$IMG_FILE ${Purple}$(printf "%+$(( COLS - 2 - $(echo ${IMG_FILE} | wc -m ) ))s" '#')"
   echo -e "# ${Green}$FSTYPE ${IWhite}filesystem detected on root ${Purple}$(printf "%+$(( COLS - 30 - $(echo ${FSTYPE} | wc -m ) ))s" '#')"
   if [ "$FSTYPE" == 'btrfs' ]; then
-    echo -e "# ${Green}${#LOCAL_SUBVOLUMES[@]} ${IWhite}btrfs volumes will be included ${Purple}$(printf "%+$(( COLS - 33 - $(echo ${#LOCAL_SUBVOLUMES[@]} | wc -m ) ))s" '#')"
-    echo -e "${Purple}# ${IWhite}btrfs volumes: ${Green}${LOCAL_SUBVOLUMES[@]} ${Purple}$(printf "%+$(( COLS - 17 - $(echo ${LOCAL_SUBVOLUMES[@]} | wc -m ) ))s" '#')"
+    echo -e "# ${Green}${#LOCAL_TOP_SUBVOLUMES[@]} ${IWhite}btrfs top volumes will be included ${Purple}$(printf "%+$(( COLS - 37 - $(echo ${#LOCAL_TOP_SUBVOLUMES[@]} | wc -m ) ))s" '#')"
+    echo -e "${Purple}# ${IWhite}btrfs top volumes: ${Green}${LOCAL_TOP_SUBVOLUMES[@]} ${Purple}$(printf "%+$(( COLS - 21 - $(echo ${LOCAL_TOP_SUBVOLUMES[@]} | wc -m ) ))s" '#')"
+    echo -e "# ${Green}${#LOCAL_NESTED_SUBVOLUMES[@]} ${IWhite}btrfs nested volumes will be included ${Purple}$(printf "%+$(( COLS - 40 - $(echo ${#LOCAL_NESTED_SUBVOLUMES[@]} | wc -m ) ))s" '#')"
+    echo -e "${Purple}# ${IWhite}btrfs nested volumes: ${Green}${LOCAL_NESTED_SUBVOLUMES[@]} ${Purple}$(printf "%+$(( COLS - 24 - $(echo ${LOCAL_NESTED_SUBVOLUMES[@]} | wc -m ) ))s" '#')"
   elif [ "$FSTYPE" == 'f2fs' ]; then
     echo -e "# ${Yellow}Autoexpand filesystem at boot not available for ${Green}f2fs ${Purple}$(printf "%+$(( COLS - 54 ))s" '#')"
     echo -e "# ${Yellow}Resize operations not available for ${Green}f2fs ${Purple}$(printf "%+$(( COLS - 43 ))s" '#')"
@@ -2030,7 +2050,7 @@ function update_img() {
       debug 'INFO' "Running function: do_resize 'expand'"
       do_resize 'expand'
 
-    # Shrinking
+    # Shrink then exit this function
     elif [ "$RESIZE_FUNCTION" == 'shrink' ]; then
       debug 'INFO' 'Running function: do_mount'
       do_mount
@@ -2039,6 +2059,10 @@ function update_img() {
       do_rsync
       debug 'INFO' "Running function: do_resize 'shrink'"
       do_resize 'shrink'
+      if [ $FSTYPE == 'ext4' ]; then
+        debug 'INFO' "Running function: do_e2fsck 'final'"
+        do_e2fsck 'final'
+      fi
       return 0
 
     else
@@ -2058,9 +2082,9 @@ function update_img() {
   debug 'INFO' 'Running function: do_rsync'
   do_rsync
 
+  # Final check of img filesystem
   if [ $FSTYPE == 'ext4' ]; then
-    # Final check of created img file
-    debug 'INFO' "Running do_e2fsck 'final'"
+    debug 'INFO' "Running function: do_e2fsck 'final'"
     do_e2fsck 'final'
   fi
 return 0
@@ -2153,13 +2177,9 @@ EOF
   debug 'DEBUG' "Creating expansion script ${TMP_DIR}/expand-fs.sh"
   cat << EOF2 > "${TMP_DIR}/expand-fs.sh"
 #!/usr/bin/bash
-#LOCAL_DEV_PTUUID=\$(lsblk -no mountpoint,ptuuid | grep '/ ' | awk '{print \$2}')
 LOCAL_DEV_ROOT_PATH=\$(findmnt -n -o SOURCE /)
 LOCAL_DEV_PATH=/dev/\$(lsblk -no pkname "\$LOCAL_DEV_ROOT_PATH")
-#LOCAL_DEV_PATH=\$(lsblk -no ptuuid,type,path | grep "\$LOCAL_DEV_PTUUID" | grep 'disk' | awk '{print \$3}')
 LOCAL_ROOT_PARTN=\$(blkid -s PART_ENTRY_NUMBER -o value -p "\$LOCAL_DEV_ROOT_PATH")
-#LOCAL_ROOT_PARTN=\$(parted -sm "\$LOCAL_DEV_PATH" print | tail -1 | cut -d : -f 1)
-#LOCAL_DEV_ROOT_PATH=\$(mount --fake | grep ' / ' | awk '{print \$1}')
 LOCAL_ROOT_START=\$(fdisk -lo start "\$LOCAL_DEV_PATH" | tail -1 | awk '{print \$1}') # blocks, 512B block size
 LOCAL_ROOT_START=\$(( LOCAL_ROOT_START * 512 )) # bytes
 
@@ -2216,13 +2236,9 @@ EOF
   debug 'DEBUG' "Creating expansion script ${TMP_DIR}/expand-fs.sh"
   cat << EOF2 > "${TMP_DIR}/expand-fs.sh"
 #!/usr/bin/bash
-#LOCAL_DEV_PTUUID=\$(lsblk -no mountpoint,ptuuid | grep '/ ' | awk '{print \$2}')
 LOCAL_DEV_ROOT_PATH=\$(findmnt -n -o SOURCE /)
 LOCAL_DEV_PATH=/dev/\$(lsblk -no pkname "\$LOCAL_DEV_ROOT_PATH")
-#LOCAL_DEV_PATH=\$(lsblk -no ptuuid,type,path | grep "\$LOCAL_DEV_PTUUID" | grep 'disk' | awk '{print \$3}')
 LOCAL_ROOT_PARTN=\$(blkid -s PART_ENTRY_NUMBER -o value -p "\$LOCAL_DEV_ROOT_PATH")
-#LOCAL_ROOT_PARTN=\$(parted -sm "\$LOCAL_DEV_PATH" print | tail -1 | cut -d : -f 1)
-#LOCAL_DEV_ROOT_PATH=\$(mount --fake | grep ' / ' | awk '{print \$1}')
 LOCAL_ROOT_START=\$(fdisk -lo start "\$LOCAL_DEV_PATH" | tail -1 | awk '{print \$1}') # blocks, 512B block size
 LOCAL_ROOT_START=\$(( LOCAL_ROOT_START * 512 )) # bytes
 
@@ -2571,7 +2587,7 @@ if [ "$EXCLUDE_FILE" = true ]; then
   fi
   debug 'DEBUG' "$EXCLUDE_FILE_LOCATION exists"
 else
-  debug 'INFO' '-f NOT selected by user, using default exclude directories'
+  debug 'INFO' '-t NOT selected by user, using default exclude directories'
 fi
 
 # Check dependencies

--- a/shrink-backup
+++ b/shrink-backup
@@ -20,6 +20,7 @@ function cleanup() {
   # exit 3 = early/clean error
   # exit 4 = abort early
   # exit 5 = abort later
+  # exit 6 = rsync error
   # exit 10 = stopped by user mid script (ctrl+c)
   local exit_code="$?"
 
@@ -28,8 +29,9 @@ function cleanup() {
       0) debug 'DEBUG' 'Cleanup function called with exit 0';;
       4) debug 'WARNING' 'Script aborted by user early, cleanup exit 4';;
       5) debug 'WARNING' 'Script aborted by user later, cleanup exit 5';;
+      6) debug 'ERROR' 'Script failed during rsync, cleanup exit 6';;
       10) echo -e "\n${Yellow}!! Script stopped by user..."; debug 'WARNING' 'Script stopped by user with ctrl+c, cleanup exit 10';;
-      *) echo -e "${Yellow}!! Cleanup function called with non zero exit code, something went wrong!!!"; debug 'ERROR' "Cleanup function called with non zero exit code: exit $exit_code";;
+      *) echo -e "${Yellow}!! Cleanup function called with non-zero exit code, something went wrong!!!"; debug 'ERROR' "Cleanup function called with non zero exit code: exit $exit_code";;
     esac
 
     echo -e "${White}## ${IWhite}Exiting and cleaning up..."
@@ -140,6 +142,7 @@ AUTORESIZE_WARNING=false
 ZOOM=false
 LOOPRUN=false
 RSYNC_DELETE='--delete'
+RSYNC_TTY=true
 F2FS=false
 #STARTLINE="$0 $*" # will produce double // if script is in $PATH
 STARTLINE="$(dirname $0)/$(basename $0) $*" # will produce absolute path if script is in $PATH
@@ -198,10 +201,12 @@ Usage: ${Green}sudo $(basename "$0") [-Uatyelzh] [--fix] [--loop] [--f2fs] image
   ${Green}-t            ${IWhite}Use exclude.txt in same folder as script to set excluded directories
                   One directory per line: "/dir" or "/dir/*" to only exclude contents
   ${Green}-y            ${IWhite}Disable prompts in script (please use this option with care!)
-  ${Green}-e            ${IWhite}DISABLE autoexpansion on root filesystem when image is booted
+  ${Green}-e            ${IWhite}Disable autoexpansion on root filesystem when image is booted
   ${Green}-l            ${IWhite}Write debug messages to logfile shrink-backup.log located in same directory as script
   ${Green}-z            ${IWhite}Make script zoom at light-speed, only question prompts might slow it down
                   Can be combined with -y for UNSAFE ultra-mega-superduper-speed
+  ${Green}-q --quiet    ${IWhite}Do not print rsync copy process
+  ${Green}--no-color    ${IWhite}Run script without color formatted text
   ${Green}--fix         ${IWhite}Try to fix the img file if -a fails with a "broken pipe" error
   ${Green}--loop [img]  ${IWhite}Loop img file and exit, works in combination with -l & -z
                   If optional [extra space] is defined, the img file will be extended with the amount before looping
@@ -245,9 +250,10 @@ while true; do
     -e) AUTOEXPAND=false; shift;;
     -l) DEBUG=true; shift;;
     -z) ZOOM=true; shift;;
+    -q|--quiet) RSYNC_TTY=false; shift;;
     --fix) RSYNC_DELETE='--delete-before'; shift;;
     --f2fs) F2FS=true; shift;;
-    --no-color) unset White IWhite Red Blue Green Yellow Purple NC; shift;;
+    --no-color) unset White IWhite Red Blue Green Yellow Purple NC; debug 'DEBUG' '--no-color selected by user'; shift;;
     --loop) LOOPRUN=true; IMG_FILE="$2"; shift 2;;
     --) break;;
     *) shift;;
@@ -986,8 +992,8 @@ function do_rsync() {
 
   echo -e "${White}## ${IWhite}Backing up files..."
   $SLEEPING
-  if [ "$TTY_AVAILABILITY" == '/dev/null' ]; then
-    echo '## This might take some time, please stand by...'
+  if [ "$TTY_AVAILABILITY" == '/dev/null' ] || [ "$RSYNC_TTY" = false ]; then
+    echo -e "${White}## ${Yellow}This might take some time, please stand by..."
   fi
   IMG_PATH=$(dirname "$IMG_FILE")
   debug 'DEBUG' "Backing up to ${IMG_PATH}${IMG_FILE}"
@@ -998,30 +1004,51 @@ function do_rsync() {
 
   if [ "$EXCLUDE_FILE" = true ]; then
     debug 'DEBUG' "Running: rsync -ahvHAX --exclude-from="$EXCLUDE_FILE_LOCATION" --exclude={${IMG_PATH}/*,${TMP_DIR},${tmp_file}} --info=progress2 --stats "$RSYNC_DELETE" --force --partial --delete-excluded / $TMP_DIR"
-    rsync -ahvHAX --exclude-from="$EXCLUDE_FILE_LOCATION" --exclude={${IMG_PATH}/*,${TMP_DIR},${tmp_file}} --info=progress2 --stats "$RSYNC_DELETE" --force --partial --delete-excluded / "$TMP_DIR" 2>&1 | tee "$TTY_AVAILABILITY"  > "$tmp_file"
-    # Get the exit status of rsync from PIPESTATUS
-    if [ "${PIPESTATUS[0]}" -ne 0 ] && [ "${PIPESTATUS[0]}" -ne 23 ]; then # code 23 = rsync warning: some files vanished before they could be transferred (code 24) at main.c
-      output=$(tail -16 "$tmp_file")
-      echo -e "${Yellow}$output\n${Red}!! RSYNC FAILED!!!"
-      debug 'BREAK'
-      debug 'ERROR' "RSYNC FAILED:\n$output\n------------------------------------------------------------------------------"
-      exit 1
-    elif [ "${PIPESTATUS[0]}" -eq 23 ]; then
-      debug 'WARNING' 'rsync code 23, some files vanished before they could be transferred (code 24) at main.c'
+    if [ "$RSYNC_TTY" = true ]; then
+      rsync -ahvHAX --exclude-from="$EXCLUDE_FILE_LOCATION" --exclude={${IMG_PATH}/*,${TMP_DIR},${tmp_file}} --info=progress2 --stats "$RSYNC_DELETE" --force --partial --delete-excluded / "$TMP_DIR" 2>&1 | tee "$TTY_AVAILABILITY" > "$tmp_file"
+    else
+      rsync -ahvHAX --exclude-from="$EXCLUDE_FILE_LOCATION" --exclude={${IMG_PATH}/*,${TMP_DIR},${tmp_file}} --info=progress2 --stats "$RSYNC_DELETE" --force --partial --delete-excluded / "$TMP_DIR" 2>&1 | tee /dev/null > "$tmp_file"
     fi
+#     if [ "${PIPESTATUS[0]}" -ne 0 ] && [ "${PIPESTATUS[0]}" -ne 23 ]; then # code 23 = rsync warning: some files vanished before they could be transferred (code 24) at main.c
+#       output=$(tail -16 "$tmp_file")
+#       echo -e "${Yellow}$output\n${Red}!! RSYNC FAILED!!!"
+#       debug 'BREAK'
+#       debug 'ERROR' "RSYNC FAILED:\n$output\n------------------------------------------------------------------------------"
+#       exit 6
+#     elif [ "${PIPESTATUS[0]}" -eq 23 ]; then
+#       debug 'WARNING' 'rsync code 23, some files vanished before they could be transferred (code 24) at main.c'
+#     fi
   else
     debug 'DEBUG' "Running: rsync -ahvHAX --exclude={/lost+found,/proc/*,/sys/*,/dev/*,/tmp/*,/run/*,/mnt/*,/media/*,/var/swap,${IMG_PATH}/*} --info=progress2 --stats "$RSYNC_DELETE" --force --partial --delete-excluded / $TMP_DIR"
-    rsync -ahvHAX --exclude={/lost+found,/proc/*,/sys/*,/dev/*,/tmp/*,/run/*,/mnt/*,/media/*,/var/swap,${IMG_PATH}/*} --info=progress2 --stats "$RSYNC_DELETE" --force --partial --delete-excluded / "$TMP_DIR" 2>&1 | tee "$TTY_AVAILABILITY" > "$tmp_file"
-    if [ "${PIPESTATUS[0]}" -ne 0 ] && [ "${PIPESTATUS[0]}" -ne 23 ]; then # code 23 = rsync warning: some files vanished before they could be transferred (code 24) at main.c
-      output=$(tail -16 "$tmp_file")
-      echo -e "${Yellow}$output\n${Red}!! RSYNC FAILED!!!"
-      debug 'BREAK'
-      debug 'ERROR' "RSYNC FAILED:\n$output\n------------------------------------------------------------------------------"
-      exit 1
-    elif [ "${PIPESTATUS[0]}" -eq 23 ]; then
-      debug 'WARNING' 'rsync code 23, some files vanished before they could be transferred (code 24) at main.c'
+    if [ "$RSYNC_TTY" = true ]; then
+      rsync -ahvHAX --exclude={/lost+found,/proc/*,/sys/*,/dev/*,/tmp/*,/run/*,/mnt/*,/media/*,/var/swap,${IMG_PATH}/*} --info=progress2 --stats "$RSYNC_DELETE" --force --partial --delete-excluded / "$TMP_DIR" 2>&1 | tee "$TTY_AVAILABILITY" > "$tmp_file"
+    else
+      rsync -ahvHAX --exclude={/lost+found,/proc/*,/sys/*,/dev/*,/tmp/*,/run/*,/mnt/*,/media/*,/var/swap,${IMG_PATH}/*} --info=progress2 --stats "$RSYNC_DELETE" --force --partial --delete-excluded / "$TMP_DIR" 2>&1 | tee /dev/null > "$tmp_file"
     fi
+#     if [ "${PIPESTATUS[0]}" -ne 0 ] && [ "${PIPESTATUS[0]}" -ne 23 ]; then # code 23 = rsync warning: some files vanished before they could be transferred (code 24) at main.c
+#       output=$(tail -16 "$tmp_file")
+#       echo -e "${Yellow}$output\n${Red}!! RSYNC FAILED!!!"
+#       debug 'BREAK'
+#       debug 'ERROR' "RSYNC FAILED:\n$output\n------------------------------------------------------------------------------"
+#       exit 6
+#     elif [ "${PIPESTATUS[0]}" -eq 23 ]; then
+#       debug 'WARNING' 'rsync code 23, some files vanished before they could be transferred (code 24) at main.c'
+#     fi
   fi
+
+  # Get the exit status of rsync from PIPESTATUS
+  if [ "${PIPESTATUS[0]}" -ne 0 ] && [ "${PIPESTATUS[0]}" -ne 23 ]; then # code 23 = rsync warning: some files vanished before they could be transferred (code 24) at main.c
+    output=$(tail -16 "$tmp_file")
+    echo -e "${Yellow}$output\n${Red}!! RSYNC FAILED!!!"
+    debug 'BREAK'
+    debug 'ERROR' "RSYNC FAILED:\nPIPESTATUS=${PIPESTATUS[0]}\n$output\n------------------------------------------------------------------------------"
+    exit 6
+  elif [ "${PIPESTATUS[0]}" -eq 23 ]; then
+    echo -e "${White}## ${Yellow}Warning, rsync code 23, some files vanished before they could be transferred (code 24) at main.c"
+    echo -e "${White}## ${Yellow}This does NOT mean the backup failed"
+    debug 'WARNING' 'rsync code 23, some files vanished before they could be transferred (code 24) at main.c'
+  fi
+
   echo -e "${White}## ${Green}Rsync done..."
   echo -e "${White}## ${IWhite}Please stand by..."
   output=$(tail -16 "$tmp_file")
@@ -1646,7 +1673,7 @@ function do_backup() {
   fi
   if [ "$RSYNC_DELETE" = '--delete-before' ]; then
     echo -e "# ${Green}--fix ${IWhite}option selected, rsync will delete files on img before copy ${Purple}$(printf "%+$(( COLS - 68 ))s" '#')"
-    debug 'DEBUG' '--fix option selected by user, rsync deleting files before copy'
+    debug 'DEBUG' '--fix selected by user, rsync deleting files before copy'
   fi
   echo -e "${Purple}# --------------------------------------------------------------------------------- #"
   echo -e "# ${IWhite}Write to logfile:              ${Green}$DEBUG ${Purple}$(printf "%+$(( COLS - 33 - $(echo ${DEBUG} | wc -m ) ))s" '#')"
@@ -2135,6 +2162,7 @@ if [ "$DEBUG" = true ]; then
   debug 'DEBUG' "UPDATE=$UPDATE"
   debug 'DEBUG' "AUTORESIZE_RUN=$AUTORESIZE_RUN"
   debug 'DEBUG' "PROMPTS=$PROMPTS"
+  debug 'DEBUG' "RSYNC_TTY=$RSYNC_TTY"
   debug 'DEBUG' "EXCLUDE_FILE=$EXCLUDE_FILE"
   debug 'DEBUG' "AUTOEXPAND=$AUTOEXPAND"
   debug 'DEBUG' "RSYNC_DELETE=$RSYNC_DELETE"

--- a/shrink-backup
+++ b/shrink-backup
@@ -243,12 +243,11 @@ Usage: ${Green}sudo $(basename "$0") [options] imagefile.img [extra space (MiB)]
                    If optional [extra space] is defined, the img file will be extended with the amount before looping
                    NOTE that only the file gets truncated, no partitions
                    Useful if you for example want to manually manage the partitions
-  ${Green}--chroot [img] ${IWhite}Loop img file, mount to a temp directory, enter chroot environment and drop to shell
+  ${Green}--chroot [img] ${IWhite}Use systemd-nspawn. Loop img file, mount to temp directory, enter chroot environment and drop to shell
                    This will let you make changes in a chroot environment directly on the img file
                    For example update with package manager or rebuild initramfs
                    The script will keep running in the background
-                   Type 'exit' when done and the script will unmount, remove loop and exit
-                   Uses systemd-nspawn
+                   Type 'exit' when done. Script will unmount, remove temp directory/loop and exit
   ${Green}--f2fs         ${IWhite}Convert root filesystem on img from ext4 to f2fs
                    Only works on new img file, not in combination with -U
                    Will make backups of fstab & cmdline.txt to: fstab.shrink-backup.bak & cmdline.txt.shrink-backup.bak
@@ -1606,10 +1605,6 @@ function make_img() {
   debug 'INFO' 'Running function: do_loop'
   do_loop
 
-  # set img variables
-  debug 'INFO' 'Running function: img_variables'
-  img_variables
-
   # Remove partition
   echo -e "${White}## ${IWhite}Removing root partition..."
   $SLEEPING
@@ -1680,6 +1675,10 @@ function make_img() {
     fi
   fi
   $SLEEPING
+
+  # Get img variables
+  debug 'INFO' 'Running function: img_variables'
+  img_variables
 
   # Format filesystem
   echo -e "${White}## ${IWhite}Formatting filesystem..."

--- a/shrink-backup
+++ b/shrink-backup
@@ -36,16 +36,16 @@ return 0
 # Function to clean up resources on script exit or termination
 function cleanup() {
   # exit 0 = cleanup after script
-  # exit 1 = later/normal error
+  # exit 1 = early/clean error
   # exit 2 = help, version & looprun
-  # exit 3 = early/clean error
+  # exit 3 = later/normal error
   # exit 4 = abort early
   # exit 5 = abort later
   # exit 6 = rsync error
-  # exit 10 = stopped by user mid script (ctrl+c)
+  # exit 10 = stopped by user (ctrl+c)
   local exit_code="$?"
 
-  if [ "$exit_code" -ne 2 ] && [ "$exit_code" -ne 3 ]; then
+  if [ "$exit_code" -ne 1 ] && [ "$exit_code" -ne 2 ]; then
     case $exit_code in
       0) debug 'DEBUG' 'Cleanup function called with exit 0';;
       4) debug 'WARNING' 'Script aborted by user early, cleanup exit 4';;
@@ -326,24 +326,33 @@ fi
 
 # loop img file and exit
 function looprun() {
+  debug 'DEBUG' "IMG_FILE=$IMG_FILE"
+  debug 'DEBUG' "ADDED_SPACE=$ADDED_SPACE"
   if [ "$ADDED_SPACE" -ne 0 ]; then
-    echo -e "${Yellow}!! ${Red}WARNING! ${Yellow}You have requested to add ${Green}${ADDED_SPACE}MiB ${Yellow}to the img file (NOT partition)"
-    debug 'INFO' 'Do you want to continue with the truncate operation? [y/n]'
-    while true; do
-      if [ "$COLORS" = true ]; then
-        read -r -p $'\e[0;37m## \e[0;97mDo you want to continue with the truncate operation? \e[0;92m[y/n] \e[0m' input
-      else
-        read -r -p '## Do you want to continue with the truncate operation? [y/n] ' input
-      fi
-      case $input in
-        [Yy]) break;;
-        [Nn]) echo -e "${Red}!! Aborting..."; exit 4;;
-        *) echo -e "${Yellow}!! ${Red}ERROR! ${Yellow}Please enter ${Green}'y' ${Yellow}or ${Green}'n'${Yellow}"; debug 'WARNING' "ERROR, please enter 'y' or 'n'";;
-      esac
-    done
-    debug 'INFO' 'Y or y pressed to confirm'
-    echo -e "${White}## ${IWhite}Truncating file by adding ${Green}${ADDED_SPACE}MiB"
-    $SLEEPING
+    debug 'INFO' 'ADDED_SPACE not 0, truncating img file'
+    if [ "$PROMPTS" = true ]; then
+      echo -e "${Yellow}!! ${Red}WARNING! ${Yellow}You have requested to add ${Green}${ADDED_SPACE}MiB ${Yellow}to the img file (NOT partition)"
+      debug 'INFO' 'Do you want to continue with the truncate operation? [y/n]'
+      while true; do
+        if [ "$COLORS" = true ]; then
+          read -r -p $'\e[0;37m## \e[0;97mDo you want to continue with the truncate operation? \e[0;92m[y/n] \e[0m' input
+        else
+          read -r -p '## Do you want to continue with the truncate operation? [y/n] ' input
+        fi
+        case $input in
+          [Yy]) break;;
+          [Nn]) echo -e "${Red}!! Aborting..."; exit 4;;
+          *) echo -e "${Yellow}!! ${Red}ERROR! ${Yellow}Please enter ${Green}'y' ${Yellow}or ${Green}'n'${Yellow}"; debug 'WARNING' "ERROR, please enter 'y' or 'n'";;
+        esac
+      done
+      debug 'INFO' 'Y or y pressed to confirm'
+      echo -e "${White}## ${IWhite}Truncating file by adding ${Green}${ADDED_SPACE}MiB"
+      $SLEEPING
+    else
+      echo -e "${White}## ${IWhite}Truncating file by adding ${Green}${ADDED_SPACE}MiB"
+      $SLEEPING
+    fi
+    debug 'DEBUG' "Running: truncate -s +\$(( $ADDED_SPACE * 1024 * 1024 )) $IMG_FILE"
     if ! output=$(truncate -s +$(( ADDED_SPACE * 1024 * 1024 )) "$IMG_FILE" 2>&1); then
       echo -e "${Yellow}$output\n${Red}!! TRUNCATE FAILED!!!"
       debug 'BREAK'
@@ -376,13 +385,6 @@ exit 2
 
 # Gather device information
 function dev_variables() {
-
-  # Run btrfs_variabless and then exit THIS function
-  if [ "$FSTYPE" == 'btrfs' ] && [ "$AUTORESIZE_RUN" = false ] && [ "$ADDED_SPACE" -eq 0 ] && [ "$UPDATE" = true ]; then
-    debug 'INFO' 'Running function: btrfs_variabless'
-    btrfs_variabless
-    return 0
-  fi
 
   ADDED_SPACE=$(( ADDED_SPACE * 1024 * 1024 )) # bytes, ADDED_SPACE=0 if AUTORESIZE_RUN=true
 
@@ -421,7 +423,7 @@ function dev_variables() {
   LOCAL_DDBOOTSECTOR=$(( (LOCAL_BOOTSECTOR + 5242880) / 512 )) # 512B blocks, 5242880 = 5MiB in bytes
   debug 'DEBUG' "LOCAL_ROOT_START=$LOCAL_ROOT_START bytes | LOCAL_BOOTSECTOR=$LOCAL_BOOTSECTOR bytes | LOCAL_DDBOOTSECTOR=$LOCAL_DDBOOTSECTOR 512B blocks"
 
-  # Set automated calculated size (btrfs_variabless if btrfs filesystem)
+  # Set automated calculated size (btrfs_variables if btrfs filesystem)
   if [ "$AUTORESIZE_RUN" = true ] || [ "$UPDATE" = false ] || [ "$FSTYPE" == 'btrfs' ]; then
     debug 'INFO' 'Calculating recommended root size'
     BLOCKSIZE=$(stat -fc %s /) # bytes
@@ -439,8 +441,8 @@ function dev_variables() {
       LOCAL_AUTORESIZE_MIN=$(( LOCAL_AUTORESIZE_MIN + 536870912 )) # adding 512MiB
       debug 'DEBUG' "LOCAL_AUTORESIZE_MIN=${LOCAL_AUTORESIZE_MIN} bytes"
     elif [ "$FSTYPE" == 'btrfs' ]; then
-      debug 'INFO' 'Running function: btrfs_variabless'
-      btrfs_variabless
+      debug 'INFO' 'Running function: btrfs_variables'
+      btrfs_variables
     fi
   fi
 
@@ -449,8 +451,10 @@ function dev_variables() {
   #LOCAL_USED_SPACE=$(( (${LOCAL_DF_OUTPUT[0]} - ${LOCAL_DF_OUTPUT[1]}) * 1024 )) # bytes, df is in 1k blocks, 0 is the first position in an array
 
   # Method 2, using "used space" straight up
-  LOCAL_DF_OUTPUT=$(df / -k --sync --output=used | tail -1) # 1k blocks
-  LOCAL_USED_SPACE=$(( LOCAL_DF_OUTPUT * 1024 )) # bytes, df is in 1k blocks
+  if [ "$FSTYPE" != 'btrfs' ]; then
+    LOCAL_DF_OUTPUT=$(df / -k --sync --output=used | tail -1) # 1k blocks
+    LOCAL_USED_SPACE=$(( LOCAL_DF_OUTPUT * 1024 )) # bytes, df is in 1k blocks
+  fi
 
   # Method 3, using du
   #LOCAL_USED_SPACE=$(du -xsb / | awk '{print $1}') # bytes
@@ -485,14 +489,13 @@ return 0
 # Gather btrfs information
 function btrfs_variables() {
 
-  BOOT_PATH=$(cat /etc/fstab | grep 'boot' | awk '{print $2}')
-  debug 'DEBUG' "BOOT_PATH=$BOOT_PATH"
-
+  debug 'INFO' 'Using btrfs fi us to get required size'
+  declare -a BTRFS_USAGE=($(btrfs fi us -T --raw / | tail -1)) # bytes
+  LOCAL_USED_SPACE=$(( BTRFS_USAGE[1] + BTRFS_USAGE[2] + BTRFS_USAGE[3] )) # adding Data single, Metadata single & System single
+  debug 'DEBUG' "LOCAL_USED_SPACE=$LOCAL_USED_SPACE"
   if [ "$AUTORESIZE_RUN" = true ]; then
-    debug 'INFO' 'Using btrfs fi du to calculate recommended size and adding 192MiB'
-    LOCAL_AUTORESIZE_MIN=$(btrfs filesystem du -s --raw / 2>/dev/null) # bytes
-    LOCAL_AUTORESIZE_MIN=$(echo "$LOCAL_AUTORESIZE_MIN" | tail -1 | awk '{print $1}')
-    LOCAL_AUTORESIZE_MIN=$(( LOCAL_AUTORESIZE_MIN + 201326592 )) # 192MiB = 201326592B
+    debug 'INFO' 'Adding 512MiB to LOCAL_USED_SPACE as recommended minimum size'
+    LOCAL_AUTORESIZE_MIN=$(( LOCAL_USED_SPACE + 536870912 ))
     debug 'DEBUG' "LOCAL_AUTORESIZE_MIN=$LOCAL_AUTORESIZE_MIN bytes"
   fi
   debug 'DEBUG' "Running: btrfs subvolume list / | awk '{print \$9}'"
@@ -500,10 +503,11 @@ function btrfs_variables() {
   debug 'DEBUG' "LOCAL_SUBVOLUMES=$(echo ${LOCAL_SUBVOLUMES[@]})"
   if [ "$EXCLUDE_FILE" = true ]; then
     debug 'INFO' 'Filtering out volumes to exclude from exclude.txt or shrink-backup.conf'
-    for ((i = 0; i < ${#LOCAL_SUBVOLUMES[@]}; i++)); do # ${#LOCAL_SUBVOLUMES[@]} gives count
-      if $(echo "/${LOCAL_SUBVOLUMES[i]}" | grep -q -f "$EXCLUDE_FILE_LOCATION"); then
-        debug 'DEBUG' "Filtering out subvolume: ${LOCAL_SUBVOLUMES[i]}"
-        unset LOCAL_SUBVOLUMES["$i"]
+    for i in ${!LOCAL_SUBVOLUMES[@]}; do
+      subvol=${LOCAL_SUBVOLUMES[i]}
+      if $(echo $subvol | grep -q -f "$EXCLUDE_FILE_LOCATION"); then
+        debug 'DEBUG' "Filtering out subvolume: $subvol"
+        unset LOCAL_SUBVOLUMES[i]
       fi
     done
     debug 'DEBUG' "After filtering: LOCAL_SUBVOLUMES=$(echo ${LOCAL_SUBVOLUMES[@]})"
@@ -554,7 +558,7 @@ function img_variables() {
       if ! [ -e "$IMG_DEV_BOOT_PATH" ] || ! [ -e "$IMG_DEV_ROOT_PATH" ]; then
         echo -e "${Red}!! LOOP PATHS CAN NOT BE SET!!!"
         debug 'ERROR' 'LOOP PATHS CAN NOT BE SET'
-        exit 1
+        exit 3
       fi
 
     # btrfs (old method)
@@ -591,7 +595,7 @@ function img_variables() {
     if ! [ -e "$IMG_DEV_ROOT_PATH" ]; then
       echo -e "${Red}!! LOOP PATHS CAN NOT BE SET!!!"
       debug 'ERROR' 'LOOP PATHS CAN NOT BE SET'
-      exit 1
+      exit 3
     fi
   fi
 
@@ -616,7 +620,7 @@ function img_variables() {
       echo -e "${Yellow}$output\n${Red}!! ROOT MOUNT FAILED!!!"
       debug 'BREAK'
       debug 'ERROR' "ROOT MOUNT FAILED:\n$output\n-------------------------------------------------------------------------------------"
-      exit 1
+      exit 3
     fi
     $SLEEPING
     debug 'DEBUG' "Running: btrfs subvolume list $TMP_DIR | awk '{print \$9}'"
@@ -630,9 +634,156 @@ return 0
 
 
 
+# Check for required dependencies
+function check_dependencies() {
+
+  # GPT
+  if [ $PARTITION_TABLE == 'gpt' ]; then
+    echo -e "${White}## ${Green}GPT partition table detected, ${Yellow}sgdisk needed, ${IWhite}checking for application..."
+    $SLEEPING
+    if ! command -v sgdisk > /dev/null 2>&1; then
+      echo -e "${Yellow}!! sgdisk is NOT installed..."
+      debug 'INFO' 'sgdisk not available on system'
+
+      # Debian based
+      if command -v apt > /dev/null 2>&1; then
+        echo -e "${White}## ${Green}apt found, ${IWhite}trying to install gdisk..."
+        # Confirm with user input
+        if [ "$PROMPTS" = true ]; then
+          echo -e "${Purple}${BREAK}${IWhite}"
+          debug 'INFO' 'Do you want to use apt to install gdisk? (will upgrade system first) [y/n]'
+          while true; do
+            if [ "$COLORS" = true ]; then
+              read -r -p $'\e[0;37m## \e[0;97mDo you want to use apt to install gdisk? (will upgrade system first) \e[0;92m[y/n] \e[0m' input
+            else
+              read -r -p '## Do you want to use apt to install gdisk? (will upgrade system first) [y/n] ' input
+            fi
+            case $input in
+              [Yy]) break;;
+              [Nn]) echo -e "${Red}!! Aborting..."; exit 4;;
+              *) echo -e "${Yellow}!! ${Red}ERROR! ${Yellow}Please enter ${Green}'y' ${Yellow}or ${Green}'n'${Yellow}"; debug 'WARNING' "ERROR, please enter 'y' or 'n'";;
+            esac
+          done
+          debug 'INFO' 'Y or y pressed to confirm'
+          debug 'BREAK'
+          debug 'DEBUG' 'Running: apt update -y && apt upgrade -y && apt install gdisk -y'
+          apt update -y && apt upgrade -y && apt install gdisk -y
+        else
+          debug 'DEBUG' 'Running: apt update -y && apt upgrade -y && apt install gdisk -y'
+          apt update -y && apt upgrade -y && apt install gdisk -y
+        fi
+
+      # Arch based
+      elif command -v pacman > /dev/null 2>&1; then
+        echo -e "${White}## ${Green}pacman found, ${IWhite}trying to install gdisk..."
+        # Confirm with user input
+        if [ "$PROMPTS" = true ]; then
+          echo -e "${Purple}${BREAK}${IWhite}"
+          debug 'INFO' 'Do you want to use pacman to install gptfdisk? (will run pacman -Syu first) [y/n]'
+          while true; do
+            if [ "$COLORS" = true ]; then
+              read -r -p $'\e[0;37m## \e[0;97mDo you want to use pacman to install gptfdisk? (will run pacman -Syu first) \e[0;92m[y/n] \e[0m' input
+            else
+              read -r -p '## Do you want to use pacman to install gptfdisk? (will run pacman -Syu first) [y/n] ' input
+            fi
+            case $input in
+              [Yy]) break;;
+              [Nn]) echo -e "${Red}!! Aborting..."; exit 4;;
+              *) echo -e "${Yellow}!! ${Red}ERROR! ${Yellow}Please enter ${Green}'y' ${Yellow}or ${Green}'n'${Yellow}"; debug 'WARNING' "ERROR, please enter 'y' or 'n'";;
+            esac
+          done
+          debug 'INFO' 'Y or y pressed to confirm'
+          debug 'BREAK'
+          debug 'DEBUG' 'Running: pacman -Syu --nocofirm && pacman -S --noconfirm gptfdisk'
+          pacman -Syu --noconfirm && pacman -S --noconfirm gptfdisk
+        else
+          debug 'DEBUG' 'Running: pacman -Syu --nocofirm && pacman -S --noconfirm gptfdisk'
+          pacman -Syu --noconfirm && pacman -S --noconfirm gptfdisk
+        fi
+
+      # Neither apt nor pacman available
+      else
+        echo -e "${Red}!! Error! ${Yellow}Installing gdisk failed! ${Green}Please install gdisk manually and retry script..."
+        debug 'ERROR' 'Installing gdisk failed, aborting exit 3'
+        echo -e "${Red}!! Aborting..."
+        exit 3
+      fi
+      echo -e "${White}## ${Green}gdisk installed successfully, ${IWhite}resuming backup..."
+      debug 'INFO' 'gdisk installed successfully'
+      $SLEEPING
+
+    # sgdisk already installed
+    else
+      echo -e "${White}## ${Green}sgdisk is available, ${IWhite}resuming backup..."
+      debug 'INFO' 'sgdisk is available on system'
+      $SLEEPING
+    fi
+  fi
+
+  # f2fs conversion
+  if [ "$f2fs" = true ]; then
+    echo -e "${White}## ${Green}--f2fs option selected, mkfs.f2fs is needed, ${IWhite}checking for application..."
+    $SLEEPING
+    if ! command -v mkfs.f2fs > /dev/null 2>&1; then
+      echo -e "${Yellow}!! mkfs.f2fs is NOT installed..."
+      debug 'INFO' 'mkfs.f2fs (f2fs-tools) not available on system'
+
+      # Debian based
+      if command -v apt > /dev/null 2>&1; then
+        echo -e "${White}## ${Green}apt found, ${IWhite}trying to install f2fs-tools..."
+        # Confirm with user input
+        if [ "$PROMPTS" = true ]; then
+          echo -e "${Purple}${BREAK}${IWhite}"
+          debug 'INFO' 'Do you want to use apt to install f2fs-tools? (will upgrade system first) [y/n]'
+          while true; do
+            if [ "$COLORS" = true ]; then
+              read -r -p $'\e[0;37m## \e[0;97mDo you want to use apt to install f2fs-tools? (will upgrade system first) \e[0;92m[y/n] \e[0m' input
+            else
+              read -r -p '## Do you want to use apt to install f2fs-tools? (will upgrade system first) [y/n] ' input
+            fi
+            case $input in
+              [Yy]) break;;
+              [Nn]) echo -e "${Red}!! Aborting..."; exit 4;;
+              *) echo -e "${Yellow}!! ${Red}ERROR! ${Yellow}Please enter ${Green}'y' ${Yellow}or ${Green}'n'${Yellow}"; debug 'WARNING' "ERROR, please enter 'y' or 'n'";;
+            esac
+          done
+          debug 'INFO' 'Y or y pressed to confirm'
+          debug 'BREAK'
+          debug 'DEBUG' 'Running: apt update -y && apt upgrade -y && apt install f2fs-tools -y'
+          apt update -y && apt upgrade -y && apt install f2fs-tools -y
+        else
+          debug 'DEBUG' 'Running: apt update -y && apt upgrade -y && apt install f2fs-tools -y'
+          apt update -y && apt upgrade -y && apt install f2fs-tools -y
+        fi
+
+      # apt not available
+      else
+        echo -e "${Red}!! Error! ${Yellow}Installing gdisk failed! ${Green}Please install mkfs.f2fs manually and retry script..."
+        debug 'ERROR' 'Installing f2fs-tools failed, aborting exit 3'
+        echo -e "${Red}!! Aborting..."
+        exit 3
+      fi
+
+    # mkfs.f2fs already installed
+    else
+      echo -e "${White}## ${Green}mkfs.f2fs is available, ${IWhite}resuming backup..."
+      debug 'INFO' 'mkfs.f2fs is available on system'
+      $SLEEPING
+    fi
+
+  # btrfs conversion
+  elif [ "$btrfs" = true ]; then
+    echo 'btrfs'
+  fi
+return
+}
+
+
+
 # loop img file
 function do_loop() {
 
+  # Find free loop
   if [ -z "$LOOP" ]; then
     LOOP=$(losetup -f)
     debug 'DEBUG' "LOOP=$LOOP"
@@ -645,7 +796,7 @@ function do_loop() {
     echo -e "${Yellow}$output\n${Red}!! LOSETUP FAILED!!!"
     debug 'BREAK'
     debug 'ERROR' "LOSETUP FAILED:\n$output\n-------------------------------------------------------------------------------------"
-    exit 1
+    exit 3
   fi
 return 0
 }
@@ -677,57 +828,34 @@ function do_mount() {
       echo -e "${Yellow}$output\n${Red}!! ROOT MOUNT FAILED!!!"
       debug 'BREAK'
       debug 'ERROR' "ROOT MOUNT FAILED:\n$output\n-------------------------------------------------------------------------------------"
-      exit 1
+      exit 3
     fi
 
   # btrfs
   elif [ "$FSTYPE" == 'btrfs' ]; then
     declare -a fstab=( $(cat /etc/fstab | grep ' / ') )
-    echo -e "${White}## ${IWhite}Mounting root subvolume..."
+    echo -e "${White}## ${IWhite}Mounting root (${Green}@${IWhite}) subvolume..."
     debug 'DEBUG' "Running: mount -o ${fstab[3]} $IMG_DEV_ROOT_PATH $TMP_DIR"
     if ! output=$(mount -o "${fstab[3]}" "$IMG_DEV_ROOT_PATH" "$TMP_DIR" 2>&1); then
       echo -e "${Yellow}$output\n${Red}!! ROOT SUBVOLUME MOUNT FAILED!!!"
       debug 'BREAK'
       debug 'ERROR' "ROOT SUBVOLUME MOUNT FAILED:\n$output\n-------------------------------------------------------------------------------------"
-      exit 1
+      exit 3
     fi
     $SLEEPING
 
     # New volumes will not be created during an update
-    # Overhaul, test this instead:
-#     for subvol in "${LOCAL_SUBVOLUMES[@]}"; do
-#       # Excluding root (@) subvolume and mounting all else in fstab, nested volumes are not in fstab
-#       if grep -q "$subvol" /etc/fstab && [[ "$subvol" != '@' ]]; then
-#         declare -a fstab=( $(cat /etc/fstab | grep "$subvol") )
-#         echo -e "${White}## ${IWhite}Mounting subvolume: ${Green}$subvol"
-#         debug 'DEBUG' "Running: mount -o ${fstab[3]} $IMG_DEV_ROOT_PATH ${TMP_DIR}${fstab[1]}"
-#         if ! output=$(mount -o "${fstab[3]}" "$IMG_DEV_ROOT_PATH" "${TMP_DIR}${fstab[1]}" 2>&1); then
-#           echo -e "${Yellow}$output\n${Red}!! SUBVOLUME MOUNT FAILED!!!"
-#           debug 'BREAK'
-#           debug 'ERROR' "SUBVOLUME MOUNT FAILED:\n$output\n-------------------------------------------------------------------------------------"
-#           exit 1
-#         fi
-#       fi
-#       $SLEEPING
-#     done
-
-    for ((i = 0; i < ${#LOCAL_SUBVOLUMES[@]}; i++)); do
-      subvol_path="${LOCAL_SUBVOLUMES[i]}"
-      #if $(cat /etc/fstab | grep -q "$subvol_path") && [[ "$subvol_path" != '@' ]]; then
+    for subvol in "${LOCAL_SUBVOLUMES[@]}"; do
       # Excluding root (@) subvolume and mounting all else in fstab, nested volumes are not in fstab
-      if grep -q "$subvol_path" /etc/fstab && [[ "$subvol_path" != '@' ]]; then
-        declare -a fstab=( $(cat /etc/fstab | grep "$subvol_path") )
-        if ! [ -d "${TMP_DIR}${fstab[1]}" ]; then
-          debug 'DEBUG' "Running: mkdir -p ${TMP_DIR}${fstab[1]}"
-          mkdir -p "${TMP_DIR}${fstab[1]}"
-        fi
-        echo -e "${White}## ${IWhite}Mounting subvolume: ${Green}$subvol_path"
+      if grep -q "$subvol" /etc/fstab && [[ "$subvol" != '@' ]]; then
+        declare -a fstab=( $(cat /etc/fstab | grep "$subvol") )
+        echo -e "${White}## ${IWhite}Mounting subvolume: ${Green}$subvol"
         debug 'DEBUG' "Running: mount -o ${fstab[3]} $IMG_DEV_ROOT_PATH ${TMP_DIR}${fstab[1]}"
-        if ! output=$(mount -o "${fstab[3]}" "$IMG_DEV_ROOT_PATH" ${TMP_DIR}${fstab[1]} 2>&1); then
+        if ! output=$(mount -o "${fstab[3]}" "$IMG_DEV_ROOT_PATH" "${TMP_DIR}${fstab[1]}" 2>&1); then
           echo -e "${Yellow}$output\n${Red}!! SUBVOLUME MOUNT FAILED!!!"
           debug 'BREAK'
           debug 'ERROR' "SUBVOLUME MOUNT FAILED:\n$output\n-------------------------------------------------------------------------------------"
-          exit 1
+          exit 3
         fi
 
       # Make sure directories exist for nested volumes
@@ -745,8 +873,8 @@ function do_mount() {
   if [ -n "$BOOT_PATH" ]; then
     if ! mount --fake | grep -q 'boot'; then
       echo -e "${Red}!! Boot found in fstab but partition not mounted, please mount and retry script!!!"
-      debug 'ERROR' 'Boot found in fstab but partition not mounted, exit 1'
-      exit 1
+      debug 'ERROR' 'Boot found in fstab but partition not mounted, exit 3'
+      exit 3
     fi
     echo -e "${White}## ${IWhite}Mounting img boot partition..."
     $SLEEPING
@@ -761,7 +889,7 @@ function do_mount() {
       echo -e "${Yellow}$output\n${Red}!! BOOT MOUNT FAILED!!!"
       debug 'BREAK'
       debug 'ERROR' "BOOT MOUNT FAILED:\n$output\n-------------------------------------------------------------------------------------"
-      exit 1
+      exit 3
     fi
   fi
 return 0
@@ -785,7 +913,7 @@ function do_e2fsck() {
   fi
 
   # Final check of filesystem
-  if [ "$*" = 'final' ]; then
+  if [ "$*" == 'final' ]; then
     echo -e "${White}## ${IWhite}Finalizing filesystem..."
     $SLEEPING
 
@@ -868,7 +996,7 @@ function do_resize() {
       echo -e "${Yellow}$output\n${Red}!! TRUNCATE FAILED!!!"
       debug 'BREAK'
       debug 'ERROR' "TRUNCATE FAILED:\n$output\n-------------------------------------------------------------------------------------"
-      exit 1
+      exit 3
     fi
 
     # Loop img file
@@ -892,7 +1020,7 @@ function do_resize() {
       debug 'BREAK'
       #debug 'ERROR' "SFDISK FAILED:\n$output\n-------------------------------------------------------------------------------------"
       debug 'ERROR' "PARTED FAILED:\n$output\n-------------------------------------------------------------------------------------"
-      exit 1
+      exit 3
     fi
 
     echo -e "${White}## ${IWhite}Recreating partition..."
@@ -903,7 +1031,7 @@ function do_resize() {
       echo -e "${Yellow}$output\n${Red}!! PARTED FAILED!!!"
       debug 'BREAK'
       debug 'ERROR' "PARTED FAILED:\n$output\n-------------------------------------------------------------------------------------"
-      exit 1
+      exit 3
     fi
 
     echo -e "${White}## ${IWhite}Resizing filesystem..."
@@ -915,7 +1043,7 @@ function do_resize() {
       echo -e "${Yellow}$output\n${Red}!! RESIZE2FS FAILED!!!"
       debug 'BREAK'
       debug 'ERROR' "RESIZE2FS FAILED:\n$output\n-------------------------------------------------------------------------------------"
-      exit 1
+      exit 3
     fi
     debug 'DEBUG' "$output\n-------------------------------------------------------------------------------------"
 
@@ -936,7 +1064,7 @@ function do_resize() {
       echo -e "${Red}$output\n${Red}!! RESIZE2FS FAILED!!!"
       debug 'BREAK'
       debug 'ERROR' "RESIZE2FS FAILED:\n$output\n-------------------------------------------------------------------------------------"
-      exit 1
+      exit 3
     fi
     debug 'DEBUG' "$output\n-------------------------------------------------------------------------------------"
 
@@ -952,7 +1080,7 @@ function do_resize() {
       echo -e "${Yellow}$output\n${Red}!! PARTED FAILED!!!"
       debug 'BREAK'
       debug 'ERROR' "PARTED FAILED:\n$output\n-------------------------------------------------------------------------------------"
-      exit 1
+      exit 3
     fi
     debug 'DEBUG' "$output\n-------------------------------------------------------------------------------------"
 
@@ -964,7 +1092,7 @@ function do_resize() {
       echo -e "${Yellow}$output\n${Red}!! TRUNCATE FAILED!!!"
       debug 'BREAK'
       debug 'ERROR' "TRUNCATE FAILED:\n$output\n-------------------------------------------------------------------------------------"
-      exit 1
+      exit 3
     fi
 
     # Final check of img filesystem
@@ -996,16 +1124,16 @@ function do_rsync() {
   if [ "$EXCLUDE_FILE" = true ]; then
     debug 'DEBUG' "Running: rsync -ahvHAX --exclude-from="$EXCLUDE_FILE_LOCATION" --exclude={${IMG_PATH}/*,${TMP_DIR},${tmp_file}} --info=progress2 --stats "$RSYNC_DELETE" --force --partial --delete-excluded --timeout=10 / $TMP_DIR"
     if [ "$RSYNC_TTY" = true ]; then
-      rsync -ahvHAX --exclude-from="$EXCLUDE_FILE_LOCATION" --exclude={${IMG_PATH}/*,${TMP_DIR},${tmp_file}} --info=progress2 --stats "$RSYNC_DELETE" --force --partial --delete-excluded --timeout=10 / "$TMP_DIR" 2>&1 | tee "$TTY_AVAILABILITY" > "$tmp_file"
+      rsync -ahvHAX --exclude-from="$EXCLUDE_FILE_LOCATION" --exclude={${IMG_PATH}/*,${TMP_DIR},${tmp_file}} --info=progress2 --stats "$RSYNC_DELETE" --force --partial --delete-excluded --timeout=30 / "$TMP_DIR" 2>&1 | tee "$TTY_AVAILABILITY" > "$tmp_file"
     else
-      rsync -ahvHAX --exclude-from="$EXCLUDE_FILE_LOCATION" --exclude={${IMG_PATH}/*,${TMP_DIR},${tmp_file}} --info=progress2 --stats "$RSYNC_DELETE" --force --partial --delete-excluded --timeout=10 / "$TMP_DIR" 2>&1 | tee /dev/null > "$tmp_file"
+      rsync -ahvHAX --exclude-from="$EXCLUDE_FILE_LOCATION" --exclude={${IMG_PATH}/*,${TMP_DIR},${tmp_file}} --info=progress2 --stats "$RSYNC_DELETE" --force --partial --delete-excluded --timeout=30 / "$TMP_DIR" 2>&1 | tee /dev/null > "$tmp_file"
     fi
   else
     debug 'DEBUG' "Running: rsync -ahvHAX --exclude={/lost+found,/proc/*,/sys/*,/dev/*,/tmp/*,/run/*,/mnt/*,/media/*,/var/swap,${IMG_PATH}/*} --info=progress2 --stats "$RSYNC_DELETE" --force --partial --delete-excluded --timeout=10 / $TMP_DIR"
     if [ "$RSYNC_TTY" = true ]; then
-      rsync -ahvHAX --exclude={/lost+found,/proc/*,/sys/*,/dev/*,/tmp/*,/run/*,/mnt/*,/media/*,/var/swap,${IMG_PATH}/*} --info=progress2 --stats "$RSYNC_DELETE" --force --partial --delete-excluded --timeout=10 / "$TMP_DIR" 2>&1 | tee "$TTY_AVAILABILITY" > "$tmp_file"
+      rsync -ahvHAX --exclude={/lost+found,/proc/*,/sys/*,/dev/*,/tmp/*,/run/*,/mnt/*,/media/*,/var/swap,${IMG_PATH}/*} --info=progress2 --stats "$RSYNC_DELETE" --force --partial --delete-excluded --timeout=30 / "$TMP_DIR" 2>&1 | tee "$TTY_AVAILABILITY" > "$tmp_file"
     else
-      rsync -ahvHAX --exclude={/lost+found,/proc/*,/sys/*,/dev/*,/tmp/*,/run/*,/mnt/*,/media/*,/var/swap,${IMG_PATH}/*} --info=progress2 --stats "$RSYNC_DELETE" --force --partial --delete-excluded --timeout=10 / "$TMP_DIR" 2>&1 | tee /dev/null > "$tmp_file"
+      rsync -ahvHAX --exclude={/lost+found,/proc/*,/sys/*,/dev/*,/tmp/*,/run/*,/mnt/*,/media/*,/var/swap,${IMG_PATH}/*} --info=progress2 --stats "$RSYNC_DELETE" --force --partial --delete-excluded --timeout=30 / "$TMP_DIR" 2>&1 | tee /dev/null > "$tmp_file"
     fi
   fi
 
@@ -1029,6 +1157,79 @@ function do_rsync() {
   debug 'DEBUG' "Rsync report:\n$output\n-------------------------------------------------------------------------------------"
   debug 'INFO' 'Rsync done'
   sleep 4
+return 0
+}
+
+
+
+# Edit config files for conversion
+function do_conversion() {
+
+  # Create partition
+  if [ "$*" == 'create_partition' ]; then
+
+    # f2fs
+    if [ "$F2FS" = true ]; then
+      debug 'INFO' '--f2fs selected by user, creating f2fs partition on img file'
+      debug 'DEBUG' "Running: parted -s -a none $LOOP unit B mkpart primary f2fs $LOCAL_ROOT_START 100%"
+      if ! output=$(parted -s -a none "$LOOP" unit B mkpart primary f2fs "$LOCAL_ROOT_START" 100% 2>&1); then
+        echo -e "${Yellow}$output\n${Red}!! PARTED FAILED!!!"
+        debug 'BREAK'
+        debug 'ERROR' "PARTED FAILED:\n$output\n-------------------------------------------------------------------------------------"
+        exit 3
+      fi
+    fi
+
+  # Format filesystem
+  elif [ "$*" == 'format_filesystem' ]; then
+
+    # f2fs
+    if [ "$F2FS" = true ]; then
+      debug 'INFO' "Using mkfs.f2fs to format root filesystem"
+      if ! output=$(mkfs.f2fs -f -U "$UUID" -l "$LABEL" "$IMG_DEV_ROOT_PATH" 2>&1 | tee "$TTY_AVAILABILITY" ); then
+        echo -e "${Yellow}$output\n${Red}!! MKFS.F2FS FAILED!!!"
+        debug 'BREAK'
+        debug 'ERROR' "MKFS.F2FS FAILED:\n$output\n-------------------------------------------------------------------------------------"
+        exit 3
+      fi
+      debug 'BREAK'
+      debug 'DEBUG' "Running: mkfs.f2fs -f -U $UUID -l $LABEL $IMG_DEV_ROOT_PATH\n$output\n-------------------------------------------------------------------------------------"
+      $SLEEPING
+
+      debug 'INFO' 'Running function: do_mount'
+      do_mount
+    fi
+
+  # Edit config files
+  elif [ "$*" == 'edit_configs' ]; then
+
+    # f2fs
+    if [ "$F2FS" = true ]; then
+      echo -e "${White}## ${IWhite}Editing img configurations for f2fs..."
+      $SLEEPING
+      echo -e "${White}## ${IWhite}Backups will be created: ${Green}/etc/fstab.shrink-backup.bak ${IWhite}& ${Green}${BOOT_PATH}/cmdline.txt.shrink-backup.bak"
+      debug 'INFO' 'Configuring fstab and cmdline.txt on img file for f2fs'
+      $SLEEPING
+
+      # Create backups
+      debug 'INFO' 'Backing up fstab & cmdline.txt into fstab.shrink-backup.bak & cmdline.shrink-backup.bak on img'
+      cp ${TMP_DIR}/etc/fstab ${TMP_DIR}/etc/fstab.shrink-backup.bak
+      cp ${TMP_DIR}${BOOT_PATH}/cmdline.txt ${TMP_DIR}${BOOT_PATH}/cmdline.txt.shrink-backup.bak
+
+      # fstab
+      debug 'DEBUG' "Old root line in fstab=$(cat ${TMP_DIR}/etc/fstab | grep ' / ')"
+      fstab_options=$(cat ${TMP_DIR}/etc/fstab | grep ' / ' | awk '{print $4}')
+      debug 'DEBUG' "Running: sed -i -e \"/${LOCAL_ROOT_PARTUUID}/s/ext4/f2fs/\" -e \"/${LOCAL_ROOT_PARTUUID}/s/${fstab_options}/${fstab_options},discard/\" ${TMP_DIR}/etc/fstab"
+      sed -i -e "/${LOCAL_ROOT_PARTUUID}/s/ext4/f2fs/" -e "/$LOCAL_ROOT_PARTUUID/s/${fstab_options}/${fstab_options},discard/" ${TMP_DIR}/etc/fstab
+      debug 'DEBUG' "New root line in fstab=$(cat ${TMP_DIR}/etc/fstab | grep ' / ')"
+
+      # cmdline.txt
+      debug 'INFO' "Old line in cmdline.txt: $(cat ${TMP_DIR}${BOOT_PATH}/cmdline.txt | grep 'console')"
+      debug 'DEBUG' "Running: sed -i 's/rootfstype=ext4/rootfstype=f2fs/' ${TMP_DIR}${BOOT_PATH}/cmdline.txt"
+      sed -i 's/rootfstype=ext4/rootfstype=f2fs/' "${TMP_DIR}${BOOT_PATH}"/cmdline.txt
+      debug 'DEBUG' "New line in cmdline.txt: $(cat ${TMP_DIR}${BOOT_PATH}/cmdline.txt | grep 'console')"
+    fi
+  fi
 return 0
 }
 
@@ -1170,7 +1371,7 @@ function make_img() {
     echo -e "${Yellow}$output\n${Red}!! DD TO LOCAL_BOOTSECTOR FAILED!!!"
     debug 'BREAK'
     debug 'ERROR' "DD TO LOCAL_BOOTSECTOR FAILED:\n$output\n-------------------------------------------------------------------------------------"
-    exit 1
+    exit 3
   fi
   output=$(echo "$output" | tail -3 )
   debug 'BREAK'
@@ -1186,7 +1387,7 @@ function make_img() {
     echo -e "${Yellow}$output\n${Red}!! TRUNCATE FAILED!!!"
     debug 'BREAK'
     debug 'ERROR' "TRUNCATE FAILED:\n$output\n-------------------------------------------------------------------------------------"
-    exit 1
+    exit 3
   fi
   $SLEEPING
 
@@ -1198,80 +1399,28 @@ function make_img() {
   debug 'INFO' 'Running function: img_variables'
   img_variables
 
+  # Check dependencies
+  debug 'INFO' 'Running function: check_dependencies'
+  check_dependencies
+
   # Remove partition
   echo -e "${White}## ${IWhite}Removing root partition..."
   $SLEEPING
 
   # GPT
   if [ $PARTITION_TABLE == 'gpt' ]; then
-    echo -e "${White}## ${Green}GPT partition table detected, ${Yellow}sgdisk needed, ${IWhite}checking for application..."
-    $SLEEPING
-    if ! command -v sgdisk > /dev/null 2>&1; then
-      echo -e "${Yellow}!! sgdisk is NOT installed..."
-      debug 'INFO' 'sgdisk not available on system'
-      read -p "Do you want to try to install gdisk? [y/n] " -n 1 -r
-      debug 'INFO' 'Do you want to try to install gdisk? [y/n]'
-      if ! [[ "$REPLY" =~ ^[Yy]$ ]]; then
-        echo ''
-        echo -e "${Red}!! Aborting..."
-        exit 5
-      fi
-      echo ''
-      debug 'INFO' 'Y or y pressed to confirm'
-      if command -v apt > /dev/null 2>&1; then
-        echo -e "${White}## ${Green}apt found, ${IWhite}trying to install gdisk..."
-        read -p "Do you want to use apt to install gdisk? (will upgrade system) [y/n] " -n 1 -r
-        debug 'INFO' 'Do you want to use apt to install gdisk? (will upgrade system) [y/n]'
-        if ! [[ "$REPLY" =~ ^[Yy]$ ]]; then
-          echo ''
-          echo -e "${Red}!! Aborting..."
-          exit 5
-        fi
-        echo ''
-        debug 'INFO' 'Y or y pressed to confirm'
-        debug 'DEBUG' 'Running: apt update -y && apt upgrade -y && apt install gdisk -y'
-        apt update -y && apt upgrade -y && apt install gdisk -y
-      elif command -v pacman > /dev/null 2>&1; then
-        echo -e "${White}## ${Green}pacman found, ${IWhite}trying to install gdisk..."
-        read -p "Do you want to use pacman to install gptfdisk? (will do -Syu first) [y/n] " -n 1 -r
-        debug 'INFO' 'Do you want to use pacman to install gptfdisk? (will do -Syu first) [y/n]'
-        if ! [[ "$REPLY" =~ ^[Yy]$ ]]; then
-          echo ''
-          echo -e "${Red}!! Aborting..."
-          exit 5
-        fi
-        echo ''
-        debug 'INFO' 'Y or y pressed to confirm'
-        debug 'DEBUG' 'Running: pacman -Syu && pacman -S gptfdisk'
-        pacman -Syu && pacman -S gptfdisk
-      else
-        echo -e "${Red}!! Error! ${Yellow}Installing gdisk failed! ${Green}Please install gdisk manually and retry script..."
-        debug 'ERROR' 'Installing gdisk failed, aborting exit 1'
-        echo -e "${Red}!! Aborting..."
-        exit 1
-      fi
-      echo -e "${White}## ${Green}gdisk installed successfully, ${IWhite}resuming backup..."
-      debug 'INFO' 'gdisk installed successfully'
-      $SLEEPING
-
-    else
-      echo -e "${White}## ${Green}sgdisk is available, ${IWhite}resuming backup..."
-      debug 'INFO' 'sgdisk is available on system'
-      $SLEEPING
-    fi
-
     debug 'INFO' 'Using sgdisk to remove root partition'
     debug 'DEBUG' "Running: sgdisk $LOOP -d $LOCAL_ROOT_PARTN"
     if ! output=$(sgdisk "$LOOP" -d "$LOCAL_ROOT_PARTN" 2>&1); then
       echo -e "${Yellow}$output\n${Red}!! SGDISK FAILED!!!"
       debug 'BREAK'
       debug 'ERROR' "SGDISK FAILED:\n$output\n-------------------------------------------------------------------------------------"
-      exit 1
+      exit 3
     fi
 
   # MBR
   else
-    # keep all of this for memory, things needed to get this to work seems to change back and forth over time
+    # Keep all of this for memory, things needed to get this to work seems to change back and forth over time
     debug 'INFO' 'Using sfdisk to remove root partition'
     #debug 'INFO' 'Using parted to remove root partition'
     debug 'DEBUG' "Running: sfdisk --delete -f $LOOP $LOCAL_ROOT_PARTN"
@@ -1286,7 +1435,7 @@ function make_img() {
       debug 'BREAK'
       debug 'ERROR' "SFDISK FAILED:\n$output\n-------------------------------------------------------------------------------------"
       #debug 'ERROR' "PARTED FAILED:\n$output\n-------------------------------------------------------------------------------------"
-      exit 1
+      exit 3
     fi
   fi
   $SLEEPING
@@ -1296,37 +1445,31 @@ function make_img() {
   $SLEEPING
   debug 'INFO' 'Using parted to recreate root partition'
 
-  # Convert to f2fs
+  # Converting
   if [ "$F2FS" = true ]; then
-    debug 'INFO' '--f2fs selected by user, creating f2fs partition on img file'
-    debug 'DEBUG' "Running: parted -s -a none $LOOP unit B mkpart primary f2fs $LOCAL_ROOT_START 100%"
-    if ! output=$(parted -s -a none "$LOOP" unit B mkpart primary f2fs "$LOCAL_ROOT_START" 100% 2>&1); then
-      echo -e "${Yellow}$output\n${Red}!! PARTED FAILED!!!"
-      debug 'BREAK'
-      debug 'ERROR' "PARTED FAILED:\n$output\n-------------------------------------------------------------------------------------"
-      exit 1
-    fi
+    debug 'INFO' "Running function: do_conversion 'create_partition'"
+    do_conversion 'create_partition'
 
   # ext4 or f2fs on root
   elif [ "$FSTYPE" == 'ext4' ] || [ "$FSTYPE" == 'f2fs' ]; then
     debug 'DEBUG' "Running: parted -s -a none $LOOP unit B mkpart primary $LOCAL_ROOT_START 100%"
-    # Figure out why I am not using below line for ALL filesystems unless converting
+    # Figure out why I am not using below line for ALL filesystems including converting
     #if ! output=$(parted -s -a none "$LOOP" unit B mkpart primary "$FSTYPE" "$LOCAL_ROOT_START" 100% 2>&1); then
     if ! output=$(parted -s -a none "$LOOP" unit B mkpart primary "$LOCAL_ROOT_START" 100% 2>&1); then
       echo -e "${Yellow}$output\n${Red}!! PARTED FAILED!!!"
       debug 'BREAK'
       debug 'ERROR' "PARTED FAILED:\n$output\n-------------------------------------------------------------------------------------"
-      exit 1
+      exit 3
     fi
 
-  # btrfs
+  # btrfs on root
   elif [ "$FSTYPE" == 'btrfs' ]; then
     debug 'DEBUG' "Running: parted -s -a none $LOOP unit B mkpart primary btrfs $LOCAL_ROOT_START 100%"
     if ! output=$(parted -s -a none "$LOOP" unit B mkpart primary btrfs "$LOCAL_ROOT_START" 100% 2>&1); then
       echo -e "${Yellow}$output\n${Red}!! PARTED FAILED!!!"
       debug 'BREAK'
       debug 'ERROR' "PARTED FAILED:\n$output\n-------------------------------------------------------------------------------------"
-      exit 1
+      exit 3
     fi
   fi
   $SLEEPING
@@ -1339,37 +1482,19 @@ function make_img() {
   UUID=$(lsblk -no uuid "$LOCAL_DEV_ROOT_PATH")
   debug 'DEBUG' "LABEL=$LABEL | UUID=$UUID"
 
-  # Convert to f2fs
+  # Converting
   if [ "$F2FS" = true ]; then
-    echo -e "${White}## ${Green}--f2fs option selected, mkfs.f2fs is needed, ${IWhite}checking if installed..."
-    $SLEEPING
-    if ! command -v mkfs.f2fs > /dev/null 2>&1; then
-      echo -e "${Yellow}!! mkfs.f2fs is NOT installed..."
-      debug 'INFO' 'mkfs.f2fs (f2fs-tools) not available on system'
-      read -p "Do you want to use apt to install f2fs-tools? (will upgrade system) [y/n] " -n 1 -r
-      debug 'INFO' 'Do you want to try to install f2fs-tools? (will upgrade system) [y/n]'
-      if ! [[ "$REPLY" =~ ^[Yy]$ ]]; then
-        echo ''
-        echo -e "${Red}!! Aborting..."
-        exit 5
-      fi
-      echo ''
-      debug 'INFO' 'Y or y pressed to confirm'
-      debug 'DEBUG' 'Running: apt update -y && apt upgrade -y && apt install f2fs-tools -y'
-      apt update -y && apt upgrade -y && apt install f2fs-tools -y
+    debug 'INFO' "Running function: do_conversion 'format_filesystem'"
+    do_conversion 'format_filesystem'
 
-    else
-      echo -e "${White}## ${Green}mkfs.f2fs is available, ${IWhite}resuming backup..."
-      debug 'INFO' 'mkfs.f2fs is available on system'
-      $SLEEPING
-    fi
-
-    debug 'DEBUG' "Running: mkfs.f2fs -f -U $UUID -l $LABEL $IMG_DEV_ROOT_PATH"
+  # f2fs
+  elif [ "$FSTYPE" == 'f2fs' ]; then
+    debug 'INFO' "Using mkfs.f2fs to format root filesystem"
     if ! output=$(mkfs.f2fs -f -U "$UUID" -l "$LABEL" "$IMG_DEV_ROOT_PATH" 2>&1 | tee "$TTY_AVAILABILITY" ); then
       echo -e "${Yellow}$output\n${Red}!! MKFS.F2FS FAILED!!!"
       debug 'BREAK'
       debug 'ERROR' "MKFS.F2FS FAILED:\n$output\n-------------------------------------------------------------------------------------"
-      exit 1
+      exit 3
     fi
     debug 'BREAK'
     debug 'DEBUG' "Running: mkfs.f2fs -f -U $UUID -l $LABEL $IMG_DEV_ROOT_PATH\n$output\n-------------------------------------------------------------------------------------"
@@ -1385,7 +1510,7 @@ function make_img() {
       echo -e "${Yellow}$output\n${Red}!! MKFS.EXT4 FAILED!!!"
       debug 'BREAK'
       debug 'ERROR' "MKFS.EXT4 FAILED:\n$output\n-------------------------------------------------------------------------------------"
-      exit 1
+      exit 3
     fi
     debug 'BREAK'
     debug 'DEBUG' "Running: mkfs.$FSTYPE -U $UUID -L $LABEL $IMG_DEV_ROOT_PATH\n$output\n-------------------------------------------------------------------------------------"
@@ -1397,31 +1522,16 @@ function make_img() {
     debug 'INFO' 'Running function: do_mount'
     do_mount
 
-  # f2fs
-  elif [ "$FSTYPE" == 'f2fs' ]; then
-    debug 'INFO' "Using mkfs.f2fs to format root filesystem"
-    if ! output=$(mkfs.f2fs -f -U "$UUID" -l "$LABEL" "$IMG_DEV_ROOT_PATH" 2>&1 | tee "$TTY_AVAILABILITY" ); then
-      echo -e "${Yellow}$output\n${Red}!! MKFS.F2FS FAILED!!!"
-      debug 'BREAK'
-      debug 'ERROR' "MKFS.F2FS FAILED:\n$output\n-------------------------------------------------------------------------------------"
-      exit 1
-    fi
-    debug 'BREAK'
-    debug 'DEBUG' "Running: mkfs.f2fs -f -U $UUID -l $LABEL $IMG_DEV_ROOT_PATH\n$output\n-------------------------------------------------------------------------------------"
-    $SLEEPING
-
-    debug 'INFO' 'Running function: do_mount'
-    do_mount
-
   # btrfs
   elif [ "$FSTYPE" == 'btrfs' ]; then
     debug 'INFO' 'Using mkfs.btrfs to format root filesystem'
     partprobe "$LOOP"
-    if ! output=$(mkfs.btrfs -f -m single -L "$LABEL" -v "$IMG_DEV_ROOT_PATH" 2>&1 | tee "$TTY_AVAILABILITY" ); then # btrfs does work with having the same uuid on 2 filesystems at the same time
+    # btrfs does work with having the same UUID on 2 filesystems at the same time but the PARTUUID is the same anyway since it's transferred with dd
+    if ! output=$(mkfs.btrfs -f -m single -L "$LABEL" -v "$IMG_DEV_ROOT_PATH" 2>&1 | tee "$TTY_AVAILABILITY" ); then
       echo -e "${Yellow}$output\n${Red}!! MKFS.BTRFS FAILED!!!"
       debug 'BREAK'
       debug 'ERROR' "MKFS.BTRFS FAILED:\n$output\n-------------------------------------------------------------------------------------"
-      exit 1
+      exit 3
     fi
     debug 'BREAK'
     debug 'DEBUG' "Running: mkfs.btrfs -f -m single -L $LABEL -v $IMG_DEV_ROOT_PATH\n$output\n-------------------------------------------------------------------------------------"
@@ -1445,44 +1555,28 @@ function make_img() {
       echo -e "${Yellow}$output\n${Red}!! ROOT MOUNT FAILED!!!"
       debug 'BREAK'
       debug 'ERROR' "BTRFS FILESYSTEM MOUNT FAILED:\n$output\n-------------------------------------------------------------------------------------"
-      exit 1
+      exit 3
     fi
     $SLEEPING
 
-    # Overhaul, test this instead:
-#     for subvol in "${LOCAL_SUBVOLUMES[@]}"; do
-#       if [[ "$subvol" == '@'* ]]; then
-#         echo -e "${White}## ${IWhite}Creating subvolume: ${Green}$subvol"
-#         debug 'DEBUG' "Running: btrfs subvolume create ${TMP_DIR}/${subvol}"
-#         if ! output=$(btrfs subvolume create "$TMP_DIR"/"$subvol" 2>&1); then
-#           echo -e "${Yellow}$output\n${Red}!! CREATE SUBVOLUME FAILED!!!"
-#           debug 'BREAK'
-#           debug 'ERROR' "CREATE SUBVOLUME FAILED:\n$output\n-------------------------------------------------------------------------------------"
-#           exit 1
-#         fi
-#       fi
-#       $SLEEPING
-#     done
-
-    # Create top subvolumes, ${#LOCAL_SUBVOLUMES[@]} gives count
-    for ((i = 0; i < ${#LOCAL_SUBVOLUMES[@]}; i++)); do
-      subvol_path="${LOCAL_SUBVOLUMES[i]}"
-      if [[ "$subvol_path" == '@'* ]]; then
-        echo -e "${White}## ${IWhite}Creating subvolume: ${Green}$subvol_path"
-        debug 'DEBUG' "Running: btrfs subvolume create ${TMP_DIR}/${subvol_path}"
-        if ! output=$(btrfs subvolume create "$TMP_DIR"/"$subvol_path" 2>&1); then
+    # Create top level subvolumes
+    for subvol in "${LOCAL_SUBVOLUMES[@]}"; do
+      if [[ "$subvol" == '@'* ]]; then
+        echo -e "${White}## ${IWhite}Creating subvolume: ${Green}$subvol"
+        debug 'DEBUG' "Running: btrfs subvolume create ${TMP_DIR}/${subvol}"
+        if ! output=$(btrfs subvolume create "$TMP_DIR"/"$subvol" 2>&1); then
           echo -e "${Yellow}$output\n${Red}!! CREATE SUBVOLUME FAILED!!!"
           debug 'BREAK'
           debug 'ERROR' "CREATE SUBVOLUME FAILED:\n$output\n-------------------------------------------------------------------------------------"
-          exit 1
+          exit 3
         fi
       fi
       $SLEEPING
     done
 
     # Mount root (@) subvolume
-    echo -e "${White}## ${IWhite}Mounting root..."
-    debug 'INFO' 'Unmounting btrfs filesystem & mounting root subvolume'
+    echo -e "${White}## ${IWhite}Mounting root (${Green}@${IWhite}) subvolume..."
+    debug 'INFO' 'Unmounting btrfs filesystem & mounting root (@) subvolume'
     debug 'DEBUG' "Running: umount $TMP_DIR"
     umount "$TMP_DIR"
     $SLEEPING
@@ -1494,7 +1588,7 @@ function make_img() {
       echo -e "${Yellow}$output\n${Red}!! ROOT SUBVOLUME MOUNT FAILED!!!"
       debug 'BREAK'
       debug 'ERROR' "ROOT SUBVOLUME MOUNT FAILED:\n$output\n-------------------------------------------------------------------------------------"
-      exit 1
+      exit 3
     fi
     $SLEEPING
 
@@ -1503,79 +1597,41 @@ function make_img() {
     debug 'INFO' 'Creating nested volumes'
     $SLEEPING
 
-    # Overhaul, test this instead:
-#     for subvol in "${LOCAL_SUBVOLUMES[@]}"; do
-#     if [[ "$subvol" != '@'* ]]; then
-#         debug 'DEBUG' "Running: mkdir -p $TMP_DIR/$(dirname $subvol)"
-#         mkdir -p "$TMP_DIR"/$(dirname "$subvol")
-#         echo -e "${White}## ${IWhite}Creating volume: ${Green}$subvol"
-#         debug 'DEBUG' "Running: btrfs subvolume create ${TMP_DIR}/$subvol"
-#         if ! output=$(btrfs subvolume create "$TMP_DIR"/"$subvol" 2>&1); then
-#           echo -e "${Yellow}$output\n${Red}!! CREATE VOLUME FAILED!!!"
-#           debug 'BREAK'
-#           debug 'ERROR' "CREATE VOLUME FAILED:\n$output\n-------------------------------------------------------------------------------------"
-#           exit 1
-#         fi
-#       fi
-#       $SLEEPING
-#     done
-
-    for ((i = 0; i < ${#LOCAL_SUBVOLUMES[@]}; i++)); do
-      subvol_path="${LOCAL_SUBVOLUMES[i]}"
-      if [[ "$subvol_path" != '@'* ]]; then
-        debug 'DEBUG' "Running: mkdir -p $TMP_DIR/$(dirname $subvol_path)"
-        mkdir -p $TMP_DIR/$(dirname $subvol_path)
-        echo -e "${White}## ${IWhite}Creating volume: ${Green}$subvol_path"
-        debug 'DEBUG' "Running: btrfs subvolume create ${TMP_DIR}/${subvol_path}"
-        if ! output=$(btrfs subvolume create "$TMP_DIR"/"$subvol_path" 2>&1); then
+    for subvol in "${LOCAL_SUBVOLUMES[@]}"; do
+    if [[ "$subvol" != '@'* ]]; then
+        debug 'DEBUG' "Running: mkdir -p $TMP_DIR/$(dirname $subvol)"
+        mkdir -p "$TMP_DIR"/$(dirname "$subvol")
+        echo -e "${White}## ${IWhite}Creating volume: ${Green}$subvol"
+        debug 'DEBUG' "Running: btrfs subvolume create ${TMP_DIR}/$subvol"
+        if ! output=$(btrfs subvolume create "$TMP_DIR"/"$subvol" 2>&1); then
           echo -e "${Yellow}$output\n${Red}!! CREATE VOLUME FAILED!!!"
           debug 'BREAK'
           debug 'ERROR' "CREATE VOLUME FAILED:\n$output\n-------------------------------------------------------------------------------------"
-          exit 1
+          exit 3
         fi
       fi
       $SLEEPING
     done
 
     # Mount volumes from fstab
-    echo -e "${White}## ${IWhite}Mounting img btrfs volumes..."
+    echo -e "${White}## ${IWhite}Mounting img btrfs volumes from fstab..."
     debug 'INFO' 'Mounting volumes'
     partprobe "$LOOP"
     $SLEEPING
 
-    # Overhaul, test this instead:
-#     for subvol in "${LOCAL_SUBVOLUMES[@]}"; do
-#       # Excluding root (@) subvolume and mounting all else in fstab, nested volumes are not in fstab
-#       if grep -q "$subvol" /etc/fstab && [[ "$subvol" != '@' ]]; then
-#         declare -a fstab=( $(cat /etc/fstab | grep "$subvol") )
-#         debug 'DEBUG' "Running: mkdir -p ${TMP_DIR}${fstab[1]}"
-#         mkdir -p "${TMP_DIR}${fstab[1]}"
-#         echo -e "${White}## ${IWhite}Mounting subvolume: ${Green}$subvol"
-#         debug 'DEBUG' "Running: mount -o ${fstab[3]} $IMG_DEV_ROOT_PATH ${TMP_DIR}${fstab[1]}"
-#         if ! output=$(mount -o "${fstab[3]}" "$IMG_DEV_ROOT_PATH" "${TMP_DIR}${fstab[1]}" 2>&1); then
-#           echo -e "${Yellow}$output\n${Red}!! SUBVOLUME MOUNT FAILED!!!"
-#           debug 'BREAK'
-#           debug 'ERROR' "SUBVOLUME MOUNT FAILED:\n$output\n-------------------------------------------------------------------------------------"
-#           exit 1
-#         fi
-#       fi
-#       $SLEEPING
-#     done
-
-    for ((i = 0; i < ${#LOCAL_SUBVOLUMES[@]}; i++)); do
-      subvol_path="${LOCAL_SUBVOLUMES[i]}"
+    for subvol in "${LOCAL_SUBVOLUMES[@]}"; do
       # Excluding root (@) subvolume and mounting all else in fstab, nested volumes are not in fstab
-      if grep -q "$subvol_path" /etc/fstab && [[ "$subvol_path" != '@' ]]; then
-        declare -a fstab=( $(cat /etc/fstab | grep "$subvol_path") )
+      if grep -q "$subvol" /etc/fstab && [[ "$subvol" != '@' ]]; then
+        declare -a fstab=( $(cat /etc/fstab | grep "$subvol") )
         debug 'DEBUG' "Running: mkdir -p ${TMP_DIR}${fstab[1]}"
-        mkdir -p ${TMP_DIR}${fstab[1]}
-        echo -e "${White}## ${IWhite}Mounting subvolume: ${Green}$subvol_path"
+        mkdir -p "${TMP_DIR}${fstab[1]}"
+        echo -e "${White}## ${IWhite}Mounting subvolume: ${Green}$subvol"
         debug 'DEBUG' "Running: mount -o ${fstab[3]} $IMG_DEV_ROOT_PATH ${TMP_DIR}${fstab[1]}"
-        if ! output=$(mount -o "${fstab[3]}" "$IMG_DEV_ROOT_PATH" ${TMP_DIR}${fstab[1]} 2>&1); then
+        if ! output=$(mount -o "${fstab[3]}" "$IMG_DEV_ROOT_PATH" "${TMP_DIR}${fstab[1]}" 2>&1); then
           echo -e "${Yellow}$output\n${Red}!! SUBVOLUME MOUNT FAILED!!!"
           debug 'BREAK'
           debug 'ERROR' "SUBVOLUME MOUNT FAILED:\n$output\n-------------------------------------------------------------------------------------"
-          exit 1
+          exit 3
         fi
       fi
       $SLEEPING
@@ -1588,7 +1644,7 @@ function make_img() {
       echo -e "${Yellow}$output\n${Red}!! BOOT MOUNT FAILED!!!"
       debug 'BREAK'
       debug 'ERROR' "BOOT MOUNT FAILED:\n$output\n-------------------------------------------------------------------------------------"
-      exit 1
+      exit 3
     fi
     $SLEEPING
   fi
@@ -1598,31 +1654,10 @@ function make_img() {
   debug 'INFO' 'Running function: do_rsync'
   do_rsync
 
-  # Edit fstab and cmdline.txt on img file for f2fs conversion
+  # Edit config files for conversion
   if [ "$F2FS" = true ]; then
-    echo -e "${White}## ${IWhite}Editing img configurations for f2fs..."
-    $SLEEPING
-    echo -e "${White}## ${IWhite}Backups will be created: ${Green}/etc/fstab.shrink-backup.bak ${IWhite}& ${Green}${BOOT_PATH}/cmdline.txt.shrink-backup.bak"
-    debug 'INFO' 'Configuring fstab and cmdline.txt on img file for f2fs'
-    $SLEEPING
-
-    # backups
-    debug 'INFO' 'Backing up fstab & cmdline.txt into fstab.shrink-backup.bak & cmdline.shrink-backup.bak on img'
-    cp ${TMP_DIR}/etc/fstab ${TMP_DIR}/etc/fstab.shrink-backup.bak
-    cp ${TMP_DIR}${BOOT_PATH}/cmdline.txt ${TMP_DIR}${BOOT_PATH}/cmdline.txt.shrink-backup.bak
-
-    # fstab
-    debug 'DEBUG' "Old root line in fstab=$(cat ${TMP_DIR}/etc/fstab | grep ' / ')"
-    fstab_options=$(cat ${TMP_DIR}/etc/fstab | grep ' / ' | awk '{print $4}')
-    debug 'DEBUG' "Running: sed -i -e \"/${LOCAL_ROOT_PARTUUID}/s/ext4/f2fs/\" -e \"/${LOCAL_ROOT_PARTUUID}/s/${fstab_options}/${fstab_options},discard/\" ${TMP_DIR}/etc/fstab"
-    sed -i -e "/${LOCAL_ROOT_PARTUUID}/s/ext4/f2fs/" -e "/$LOCAL_ROOT_PARTUUID/s/${fstab_options}/${fstab_options},discard/" ${TMP_DIR}/etc/fstab
-    debug 'DEBUG' "New root line in fstab=$(cat ${TMP_DIR}/etc/fstab | grep ' / ')"
-
-    # cmdline.txt
-    debug 'INFO' "Old line in cmdline.txt: $(cat ${TMP_DIR}${BOOT_PATH}/cmdline.txt | grep 'console')"
-    debug 'DEBUG' "Running: sed -i 's/rootfstype=ext4/rootfstype=f2fs/' ${TMP_DIR}${BOOT_PATH}/cmdline.txt"
-    sed -i 's/rootfstype=ext4/rootfstype=f2fs/' "${TMP_DIR}${BOOT_PATH}"/cmdline.txt
-    debug 'DEBUG' "New line in cmdline.txt: $(cat ${TMP_DIR}${BOOT_PATH}/cmdline.txt | grep 'console')"
+    debug 'INFO' "Running function: do_conversion 'edit_configs'"
+    do_conversion 'edit_configs'
   fi
 
   # Final check of created img file
@@ -1630,7 +1665,6 @@ function make_img() {
     debug 'INFO' "Running function: do_e2fsck 'final'"
     do_e2fsck 'final'
   fi
-
 return 0
 }
 
@@ -1642,12 +1676,12 @@ function update_img() {
   # Make sure img file exists
   if ! [ -f "$IMG_FILE" ]; then
     echo -e "${Red}!! ERROR! ${Green}$IMG_FILE ${Yellow}does not exist!"
-    debug 'ERROR' "$IMG_FILE does not exist, exit 1"
-    exit 1
+    debug 'ERROR' "$IMG_FILE does not exist, exit 3"
+    exit 3
   fi
 
   debug 'INFO' 'Running function: dev_variables'
-  # btrfs_variabless is run within dev_variables
+  # btrfs_variables is run within dev_variables
   dev_variables
 
   debug 'INFO' 'Running function: do_loop'
@@ -1698,8 +1732,8 @@ function update_img() {
   echo -e "# ${Green}$IMG_FILE ${Purple}$(printf "%+$(( COLS - 2 - $(echo ${IMG_FILE} | wc -m ) ))s" '#')"
   echo -e "# ${Green}$FSTYPE ${IWhite}filesystem detected on root ${Purple}$(printf "%+$(( COLS - 30 - $(echo ${FSTYPE} | wc -m ) ))s" '#')"
   if [ "$FSTYPE" == 'btrfs' ]; then
-    echo -e "# ${Green}${#LOCAL_SUBVOLUMES[@]} ${IWhite}btrfs volumes will be included"
-    echo -e "${Purple}# ${IWhite}btrfs volumes: ${Green}${LOCAL_SUBVOLUMES[@]}"
+    echo -e "# ${Green}${#LOCAL_SUBVOLUMES[@]} ${IWhite}btrfs volumes will be included ${Purple}$(printf "%+$(( COLS - 33 - $(echo ${#LOCAL_SUBVOLUMES[@]} | wc -m ) ))s" '#')"
+    echo -e "${Purple}# ${IWhite}btrfs volumes: ${Green}${LOCAL_SUBVOLUMES[@]} ${Purple}$(printf "%+$(( COLS - 17 - $(echo ${LOCAL_SUBVOLUMES[@]} | wc -m ) ))s" '#')"
   elif [ "$FSTYPE" == 'f2fs' ]; then
     echo -e "# ${Yellow}Autoexpand filesystem at boot not available for ${Green}f2fs ${Purple}$(printf "%+$(( COLS - 54 ))s" '#')"
     echo -e "# ${Yellow}Resize operations not available for ${Green}f2fs ${Purple}$(printf "%+$(( COLS - 43 ))s" '#')"
@@ -1814,7 +1848,6 @@ function update_img() {
     debug 'INFO' "Running do_e2fsck 'final'"
     do_e2fsck 'final'
   fi
-
 return 0
 }
 
@@ -1849,8 +1882,8 @@ EOF
     ln -s /etc/systemd/system/expand-fs.service ${TMP_DIR}/etc/systemd/system/basic.target.wants/expand-fs.service
   fi
 
-  echo -e "${White}## ${Green}Manjaro filesystem autoresizing at boot..."
-  debug 'INFO' 'Manjaro filesystem autoresizing at boot'
+  echo -e "${White}## ${Green}Manjaro-arm filesystem autoresizing at boot..."
+  debug 'INFO' 'Manjaro-arm filesystem autoresizing at boot'
   $SLEEPING
 return 0
 }
@@ -1982,8 +2015,8 @@ EOF2
   debug 'DEBUG' 'Making /expand-fs.sh executable'
   chmod +x ${TMP_DIR}/expand-fs.sh
 
-  echo -e "${White}## ${Green}ArchLinuxArm filesystem autoresizing at boot..."
-  debug 'INFO' 'ArchLinuxArm filesystem autoresizing at boot'
+  echo -e "${White}## ${Green}ArchLinux-arm filesystem autoresizing at boot..."
+  debug 'INFO' 'ArchLinux-arm filesystem autoresizing at boot'
   $SLEEPING
 return 0
 }
@@ -2078,8 +2111,8 @@ fi
 # Check if the image file has the correct extension
 if [ "$LOOPRUN" = false ] && [[ "$IMG_FILE" != *.img ]]; then
   echo -e "${Red}!! ERROR! ${Yellow}File must have ${Green}.img ${Yellow}extension"
-  debug 'ERROR' 'File must have .img extension, exit 3'
-  exit 3
+  debug 'ERROR' 'File must have .img extension, exit 1'
+  exit 1
 fi
 
 # Setting ADDED_SPACE to 0 if AUTORESIZE_RUN option is enabled
@@ -2091,24 +2124,21 @@ if [ "$AUTORESIZE_RUN" = true ] && [ "$LOOPRUN" = false ]; then
   fi
   ADDED_SPACE=0
   debug 'INFO' '-a selected by user, setting ADDED_SPACE to 0 (non-zero value)'
-  debug 'DEBUG' "ADDED_SPACE=$ADDED_SPACE"
 fi
 
 # Setting ADDED_SPACE to 0 if update is requested and variable ADDED_SPACE is a zero value
 if [ $UPDATE = true ] && [ -z "$ADDED_SPACE" ] && [ "$LOOPRUN" = false ]; then
   ADDED_SPACE=0
   debug 'INFO' '-U selected, -a not selected or [extra space] not provided by user, setting ADDED_SPACE to 0 (non-zero value)'
-  debug 'DEBUG' "ADDED_SPACE=$ADDED_SPACE"
 fi
 
 # Setting ADDED_SPACE to 0 if --loop is selected without providing [extra space]
 if [ "$LOOPRUN" = true ] && [ -z "$ADDED_SPACE" ]; then
   ADDED_SPACE=0
   debug 'INFO' '--loop selected and [extra space] not provided by user, setting ADDED_SPACE to 0 (non-zero value)'
-  debug 'DEBUG' "ADDED_SPACE=$ADDED_SPACE"
 fi
 
-# Requesting user to input [extra space] if new image and not provided
+# Requesting user to input [extra space] if not provided while making new image
 if [ "$UPDATE" = false ] && [ -z "$ADDED_SPACE" ]; then
   debug 'INFO' 'New image without -a option and no [extra space] defined by user, requesting user input'
   echo -e "${White}## ${IWhite}New image requested without ${Yellow}-a ${IWhite}option and no provided ${Yellow}[extra space]"
@@ -2155,8 +2185,8 @@ echo -e "${White}## ${IWhite}Scanning filesystem and calculating..."
 # Make sure boot is mounted if it exists in fstab
 if grep -q 'boot' /etc/fstab && ! mount --fake | grep -q 'boot'; then
   echo -e "${Red}!! Boot found in fstab but partition not mounted, please mount and retry script!!!"
-  debug 'ERROR' 'Boot found in fstab but partition not mounted, exit 3'
-  exit 3
+  debug 'ERROR' 'Boot found in fstab but partition not mounted, exit 1'
+  exit 1
 fi
 
 # Check what filesystem root is using and set LOCAL_DEV_PATH & PARTITION_TABLE
@@ -2165,7 +2195,7 @@ debug 'INFO' "$FSTYPE root filesystem detected"
 debug 'DEBUG' "FSTYPE=$FSTYPE"
 if [ "$FSTYPE" == 'ext4' ] || [ "$FSTYPE" == 'f2fs' ]; then
   LOCAL_DEV_PTUUID=$(lsblk -no mountpoint,ptuuid | grep '/ ' | awk '{print $2}')
-else
+elif [ "$FSTYPE" == 'btrfs' ]; then
   #LOCAL_DEV_PTUUID=$(lsblk -no fsroots,ptuuid | grep '/ ' | awk '{print $2}')
   LOCAL_DEV_PTUUID=$(lsblk -no path,ptuuid $(mount --fake | grep ' / ' | awk '{print $1}') | awk '{print $2}')
 fi
@@ -2176,34 +2206,63 @@ PARTITION_TABLE=$(parted "$LOCAL_DEV_PATH" print | grep -i 'Partition Table' | a
 
 if [ "$FSTYPE" == 'f2fs' ] || [ "$F2FS" = true ]; then
   if [ "$FSTYPE" == 'f2fs' ] && [ "$F2FS" = true ]; then
-    echo -e "${Red}!! ERROR! ${Green}--f2fs ${Yellow}selected on ${Green}f2fs root filesystem${Yellow}, conversion not needed"
+    echo -e "${Red}!! ERROR! ${Green}--f2fs ${Yellow}selected with existing ${Green}f2fs filesystem${Yellow}, conversion not needed"
     echo -e "${Red}!! Run script without ${Green}--f2fs"
-    debug 'ERROR' '--f2fs selected on f2fs root filesystem, conversion not needed, exit 3'
-    exit 3
+    debug 'ERROR' '--f2fs selected with existing f2fs filesystem, conversion not needed, exit 1'
+    exit 1
   elif [ "$F2FS" = true ] && [ "$UPDATE" = true ]; then
     echo -e "${Red}!! ERROR! ${Green}--f2fs ${Yellow}selected in combination with ${Green}-U${Yellow}, conversion not possible"
     echo -e "${Red}!! ${Yellow}Create new img to enable ${Green}f2fs conversion"
-    debug 'ERROR' '--f2fs selected in combination with -U, conversion not possible, exit 3'
-    exit 3
+    debug 'ERROR' '--f2fs selected in combination with -U, operation not supported, exit 1'
+    exit 1
   elif [ "$FSTYPE" == 'f2fs' ] && [ "$UPDATE" = true ] && [ "$AUTORESIZE_RUN" = true ]; then
     echo -e "${Red}!! ERROR! ${Green}-U ${Yellow}selected in combination with ${Green}-a${Yellow}, operation not supported"
     echo -e "${Red}!! ${Yellow}Only creation of new img backups support ${Green}operations with -a when using f2fs on root"
-    debug 'ERROR' '-U selected in combination with -a, operation not supported, exit 3'
-    exit 3
+    debug 'ERROR' '-U selected in combination with -a on f2fs filesystem, operation not supported, exit 1'
+    exit 1
   elif [ "$FSTYPE" == 'f2fs' ] && [ "$UPDATE" = true ] && [ "$ADDED_SPACE" -ne 0 ]; then
     echo -e "${Red}!! ERROR! ${Green}-U ${Yellow}selected in combination with ${Green}[extra space]${Yellow}, operation not supported"
     echo -e "${Red}!! ${Yellow}Only creation of new img backups support ${Green}operations with [extra space] when using f2fs on root"
-    debug 'ERROR' '-U selected in combination with [extra space], operation not supported, exit 3'
-    exit 3
+    debug 'ERROR' '-U selected in combination with [extra space] on f2fs filesystem, operation not supported, exit 1'
+    exit 1
   fi
   debug 'INFO' 'f2fs filesystem or conversion to f2fs requested, disabling autoexpansion'
   AUTOEXPAND=false
+fi
+
+# Detect OS
+if [ -e /etc/apt/sources.list.d/raspi.list ]; then
+  echo -e "${White}## ${Green}Raspberry pi detected"
+  OS='rpi'
+  debug 'INFO' 'Raspberry pi detected'
+  $SLEEPING
+elif [ -e /etc/armbian-release ] || grep -qsi 'armbian' /etc/os-release; then
+  echo -e "${White}## ${Green}Armbian detected"
+  OS='armbian'
+  debug 'INFO' 'Armbian detected'
+  $SLEEPING
+elif grep -qsi 'manjaro' /etc/os-release; then
+  echo -e "${White}## ${Green}Manjaro-arm detected"
+  OS='manjaro-arm'
+  debug 'INFO' 'Manjaro-arm detected'
+  $SLEEPING
+elif grep -qsi 'archlinuxarm' /etc/os-release; then
+  echo -e "${White}## ${Green}ArchLinux-arm detected"
+  OS='archlinux-arm'
+  debug 'INFO' 'ArchLinux-arm detected'
+  $SLEEPING
+else
+  echo -e "${Yellow}!! Unknown OS"
+  OS='unknown'
+  debug 'INFO' 'Unknown OS'
+  $SLEEPING
 fi
 
 # Enter variables into logfile
 if [ "$DEBUG" = true ]; then
   debug 'BREAK'
   debug 'DEBUG' "INSTALL_METHOD=$INSTALL_METHOD"
+  debug 'DEBUG' "OS=$OS"
   debug 'DEBUG' "IMG_FILE=$IMG_FILE"
   debug 'DEBUG' "PARTITION_TABLE=$PARTITION_TABLE"
   debug 'DEBUG' "UPDATE=$UPDATE"
@@ -2215,6 +2274,7 @@ if [ "$DEBUG" = true ]; then
   debug 'DEBUG' "RSYNC_DELETE=$RSYNC_DELETE"
   debug 'DEBUG' "F2FS=$F2FS"
   debug 'DEBUG' "TTY_AVAILABILITY=$TTY_AVAILABILITY"
+  debug 'DEBUG' "ADDED_SPACE=$ADDED_SPACE"
   debug 'BREAK'
 fi
 
@@ -2223,8 +2283,8 @@ if [ "$EXCLUDE_FILE" = true ]; then
   debug 'INFO' "-f selected by user, using $EXCLUDE_FILE_LOCATION"
   if ! [ -f "$EXCLUDE_FILE_LOCATION" ]; then
     echo -e "${Red}!! ERROR! ${Green}-f selected but ${Yellow}$EXCLUDE_FILE_LOCATION does not exist!"
-    debug 'ERROR' "$EXCLUDE_FILE_LOCATION does not exist, exit 3"
-    exit 3
+    debug 'ERROR' "$EXCLUDE_FILE_LOCATION does not exist, exit 1"
+    exit 1
   fi
   debug 'DEBUG' "$EXCLUDE_FILE_LOCATION exists"
 else
@@ -2241,41 +2301,17 @@ else
   update_img
 fi
 
-# Check if autoexpansion is requested and run required function
+# Run autoexpansion
 if [ "$AUTOEXPAND" = true ]; then
-  echo -e "${White}## ${IWhite}Enabling fs-autoexpand..."
-  debug 'INFO' 'Checking OS for autoexpand function'
+  debug 'INFO' 'Running autoexpand function'
   $SLEEPING
-  if grep -qsi 'manjaro' /etc/os-release; then
-    echo -e "${White}## ${Green}Manjaro OS detected..."
-    debug 'INFO' 'Manjaro OS detected'
-    debug 'INFO' 'Running function: autoexpansion_manjaro'
-    $SLEEPING
-    autoexpansion_manjaro
-  elif [ -e /etc/armbian-release ] || grep -qsi 'armbian' /etc/os-release; then
-    echo -e "${White}## ${Green}Armbian OS detected..."
-    debug 'INFO' 'Armbian OS detected'
-    debug 'INFO' 'Running function: autoexpansion_armbian'
-    $SLEEPING
-    autoexpansion_armbian
-  elif [ -e /etc/apt/sources.list.d/raspi.list ]; then
-    echo -e "${White}## ${Green}Raspberry pi detected..."
-    debug 'INFO' 'Raspberry pi detected'
-    debug 'INFO' 'Running function: autoexpansion_rpi'
-    $SLEEPING
-    autoexpansion_rpi
-  elif grep -qsi 'archlinuxarm' /etc/os-release; then
-    echo -e "${White}## ${Green}ArchLinuxArm detected..."
-    debug 'INFO' 'ArchLinuxArm detected'
-    debug 'INFO' 'Running function: autoexpansion_arch'
-    $SLEEPING
-    autoexpansion_arch
-  else
-    echo -e "${Yellow}!! No autoexpand option available for this OS..."
-    debug 'WARNING' 'No autoexpand option available for this OS'
-    AUTOEXPAND='failed'
-    $SLEEPING
-  fi
+  case "$OS" in
+    rpi) echo -e "${White}## ${IWhite}Enabling autoexpansion for ${Green}Raspberry pi..."; debug 'INFO' 'Running function: autoexpansion_rpi'; autoexpansion_rpi;;
+    armbian) echo -e "${White}## ${IWhite}Enabling autoexpansion for ${Green}Armbian..."; debug 'INFO' 'Running function: autoexpansion_armbian'; autoexpansion_armbian;;
+    manjaro-arm) echo -e "${White}## ${IWhite}Enabling autoexpansion for ${Green}Manjaro-arm..."; debug 'INFO' 'Running function: autoexpansion_manjaro'; autoexpansion_manjaro;;
+    archlinux-arm) echo -e "${White}## ${IWhite}Enabling autoexpansion for ${Green}ArchLinux-arm..."; debug 'INFO' 'Running function: autoexpansion_arch'; autoexpansion_arch;;
+    unknown) echo -e "${Yellow}!! No autoexpand option available for this OS!"; debug 'WARNING' 'No autoexpand option available for this OS'; AUTOEXPAND='failed';;
+  esac
 fi
 
 print_result

--- a/shrink-backup
+++ b/shrink-backup
@@ -568,7 +568,8 @@ function dev_variables() {
     LOCAL_ROOT_PARTUUID=$(lsblk -no partuuid "$LOCAL_DEV_ROOT_PATH")
     debug 'DEBUG' "LOCAL_ROOT_UUID=$LOCAL_ROOT_UUID | LOCAL_ROOT_PARTUUID=$LOCAL_ROOT_PARTUUID"
   fi
-  LOCAL_ROOT_PARTN=$(parted -sm "$LOCAL_DEV_PATH" print | tail -1 | cut -d : -f 1)
+  LOCAL_ROOT_PARTN=$(blkid -s PART_ENTRY_NUMBER -o value -p "$LOCAL_DEV_ROOT_PATH")
+  #LOCAL_ROOT_PARTN=$(parted -sm "$LOCAL_DEV_PATH" print | tail -1 | cut -d : -f 1)
   debug 'DEBUG' "LOCAL_ROOT_PARTN=$LOCAL_ROOT_PARTN"
 
   # Collect information about partition sizes
@@ -1343,14 +1344,14 @@ function do_rsync() {
   debug 'DEBUG' "tmp_file=$tmp_file"
 
   if [ "$EXCLUDE_FILE" = true ]; then
-    debug 'DEBUG' "Running: rsync -ahvHAX --exclude-from="$EXCLUDE_FILE_LOCATION" --exclude={${IMG_PATH}/*,${TMP_DIR},${tmp_file}} --info=progress2 --stats "$RSYNC_DELETE" --force --partial --delete-excluded --timeout=10 / $TMP_DIR"
+    debug 'DEBUG' "Running: rsync -ahvHAX --exclude-from="$EXCLUDE_FILE_LOCATION" --exclude={${IMG_PATH}/*,${TMP_DIR},${tmp_file}} --info=progress2 --stats "$RSYNC_DELETE" --force --partial --delete-excluded --timeout=30 / $TMP_DIR"
     if [ "$RSYNC_TTY" = true ]; then
       rsync -ahvHAX --exclude-from="$EXCLUDE_FILE_LOCATION" --exclude={${IMG_PATH}/*,${TMP_DIR},${tmp_file}} --info=progress2 --stats "$RSYNC_DELETE" --force --partial --delete-excluded --timeout=30 / "$TMP_DIR" 2>&1 | tee "$TTY_AVAILABILITY" > "$tmp_file"
     else
       rsync -ahvHAX --exclude-from="$EXCLUDE_FILE_LOCATION" --exclude={${IMG_PATH}/*,${TMP_DIR},${tmp_file}} --info=progress2 --stats "$RSYNC_DELETE" --force --partial --delete-excluded --timeout=30 / "$TMP_DIR" 2>&1 | tee /dev/null > "$tmp_file"
     fi
   else
-    debug 'DEBUG' "Running: rsync -ahvHAX --exclude={/lost+found,/proc/*,/sys/*,/dev/*,/tmp/*,/run/*,/mnt/*,/media/*,/var/swap,/snap/*,${IMG_PATH}/*} --info=progress2 --stats "$RSYNC_DELETE" --force --partial --delete-excluded --timeout=10 / $TMP_DIR"
+    debug 'DEBUG' "Running: rsync -ahvHAX --exclude={/lost+found,/proc/*,/sys/*,/dev/*,/tmp/*,/run/*,/mnt/*,/media/*,/var/swap,/snap/*,${IMG_PATH}/*} --info=progress2 --stats "$RSYNC_DELETE" --force --partial --delete-excluded --timeout=30 / $TMP_DIR"
     if [ "$RSYNC_TTY" = true ]; then
       rsync -ahvHAX --exclude={/lost+found,/proc/*,/sys/*,/dev/*,/tmp/*,/run/*,/mnt/*,/media/*,/var/swap,/snap/*,${IMG_PATH}/*} --info=progress2 --stats "$RSYNC_DELETE" --force --partial --delete-excluded --timeout=30 / "$TMP_DIR" 2>&1 | tee "$TTY_AVAILABILITY" > "$tmp_file"
     else
@@ -2145,6 +2146,7 @@ ExecStop=/bin/bash -c "/usr/bin/rm /etc/systemd/system/basic.target.wants/expand
 WantedBy=basic.target
 EOF
 
+  # Enable service by creating symlink
   if ! [ -L "${TMP_DIR}/etc/systemd/system/basic.target.wants/expand-fs.service" ]; then
     debug 'DEBUG' "Enabling systemd service by creating symlink: ln -s /etc/systemd/system/expand-fs.service ${TMP_DIR}/etc/systemd/system/basic.target.wants/expand-fs.service"
     ln -s /etc/systemd/system/expand-fs.service ${TMP_DIR}/etc/systemd/system/basic.target.wants/expand-fs.service
@@ -2154,11 +2156,13 @@ EOF
   debug 'DEBUG' "Creating expansion script ${TMP_DIR}/expand-fs.sh"
   cat << EOF2 > "${TMP_DIR}/expand-fs.sh"
 #!/usr/bin/bash
-LOCAL_DEV_PTUUID=\$(lsblk -no mountpoint,ptuuid | grep '/ ' | awk '{print \$2}')
-LOCAL_DEV_PATH=\$(lsblk -no ptuuid,type,path | grep "\$LOCAL_DEV_PTUUID" | grep 'disk' | awk '{print \$3}')
-LOCAL_ROOT_PARTN=\$(parted -sm "\$LOCAL_DEV_PATH" print | tail -1 | cut -d : -f 1)
-#LOCAL_DEV_ROOT_PATH=\$(lsblk -no mountpoint,path | grep '/ ' | awk '{print \$2}')
-LOCAL_DEV_ROOT_PATH=\$(mount --fake | grep ' / ' | awk '{print \$1}')
+#LOCAL_DEV_PTUUID=\$(lsblk -no mountpoint,ptuuid | grep '/ ' | awk '{print \$2}')
+LOCAL_DEV_ROOT_PATH=\$(findmnt -n -o SOURCE /)
+LOCAL_DEV_PATH=/dev/\$(lsblk -no pkname "\$LOCAL_DEV_ROOT_PATH")
+#LOCAL_DEV_PATH=\$(lsblk -no ptuuid,type,path | grep "\$LOCAL_DEV_PTUUID" | grep 'disk' | awk '{print \$3}')
+LOCAL_ROOT_PARTN=\$(blkid -s PART_ENTRY_NUMBER -o value -p "\$LOCAL_DEV_ROOT_PATH")
+#LOCAL_ROOT_PARTN=\$(parted -sm "\$LOCAL_DEV_PATH" print | tail -1 | cut -d : -f 1)
+#LOCAL_DEV_ROOT_PATH=\$(mount --fake | grep ' / ' | awk '{print \$1}')
 LOCAL_ROOT_START=\$(fdisk -lo start "\$LOCAL_DEV_PATH" | tail -1 | awk '{print \$1}') # blocks, 512B block size
 LOCAL_ROOT_START=\$(( LOCAL_ROOT_START * 512 )) # bytes
 
@@ -2205,20 +2209,23 @@ ExecStop=/bin/bash -c "/usr/bin/rm /etc/systemd/system/basic.target.wants/expand
 WantedBy=basic.target
 EOF
 
+  # Enable service by creating symlink
   if ! [ -L "${TMP_DIR}/etc/systemd/system/basic.target.wants/expand-fs.service" ]; then
     debug 'DEBUG' "Enabling systemd service by creating symlink: ln -s /etc/systemd/system/expand-fs.service ${TMP_DIR}/etc/systemd/system/basic.target.wants/expand-fs.service"
     ln -s /etc/systemd/system/expand-fs.service ${TMP_DIR}/etc/systemd/system/basic.target.wants/expand-fs.service
   fi
 
   # Creating script for autoexpansion
-  debug 'DEBUG' 'Creating expansion script ${TMP_DIR}/expand-fs.sh'
+  debug 'DEBUG' "Creating expansion script ${TMP_DIR}/expand-fs.sh"
   cat << EOF2 > "${TMP_DIR}/expand-fs.sh"
 #!/usr/bin/bash
-LOCAL_DEV_PTUUID=\$(lsblk -no mountpoint,ptuuid | grep '/ ' | awk '{print \$2}')
-LOCAL_DEV_PATH=\$(lsblk -no ptuuid,type,path | grep "\$LOCAL_DEV_PTUUID" | grep 'disk' | awk '{print \$3}')
-LOCAL_ROOT_PARTN=\$(parted -sm "\$LOCAL_DEV_PATH" print | tail -1 | cut -d : -f 1)
-#LOCAL_DEV_ROOT_PATH=\$(lsblk -no mountpoint,path | grep '/ ' | awk '{print \$2}')
-LOCAL_DEV_ROOT_PATH=\$(mount --fake | grep ' / ' | awk '{print \$1}')
+#LOCAL_DEV_PTUUID=\$(lsblk -no mountpoint,ptuuid | grep '/ ' | awk '{print \$2}')
+LOCAL_DEV_ROOT_PATH=\$(findmnt -n -o SOURCE /)
+LOCAL_DEV_PATH=/dev/\$(lsblk -no pkname "\$LOCAL_DEV_ROOT_PATH")
+#LOCAL_DEV_PATH=\$(lsblk -no ptuuid,type,path | grep "\$LOCAL_DEV_PTUUID" | grep 'disk' | awk '{print \$3}')
+LOCAL_ROOT_PARTN=\$(blkid -s PART_ENTRY_NUMBER -o value -p "\$LOCAL_DEV_ROOT_PATH")
+#LOCAL_ROOT_PARTN=\$(parted -sm "\$LOCAL_DEV_PATH" print | tail -1 | cut -d : -f 1)
+#LOCAL_DEV_ROOT_PATH=\$(mount --fake | grep ' / ' | awk '{print \$1}')
 LOCAL_ROOT_START=\$(fdisk -lo start "\$LOCAL_DEV_PATH" | tail -1 | awk '{print \$1}') # blocks, 512B block size
 LOCAL_ROOT_START=\$(( LOCAL_ROOT_START * 512 )) # bytes
 

--- a/shrink-backup
+++ b/shrink-backup
@@ -12,6 +12,27 @@
 #    LICENSE file in the root directory of this source tree.
 ##############################################################################
 
+
+
+function debug() {
+  local log_level="$1"
+  local log_message="$2"
+  if [ "$DEBUG" = true ]; then
+    if [ "$log_level" = 'BREAK' ]; then
+      echo '------------------------------------------------------------------------------' >> "$LOG_FILE"
+    else
+      if [ $log_level = 'INFO' ]; then
+        echo -e "$(date +"%Y-%m-%d %H:%M:%S") [$log_level]  - $log_message" >> "$LOG_FILE"
+      else
+        echo -e "$(date +"%Y-%m-%d %H:%M:%S") [$log_level] - $log_message" >> "$LOG_FILE"
+      fi
+    fi
+  fi
+return 0
+}
+
+
+
 # Function to clean up resources on script exit or termination
 function cleanup() {
   # exit 0 = cleanup after script
@@ -115,6 +136,8 @@ function cleanup() {
 trap cleanup EXIT SIGTERM
 trap "exit 10" SIGINT
 
+
+
 # Function to pause script execution and prompt for user input
 function pause() {
   read -p "$*"
@@ -122,7 +145,9 @@ function pause() {
 # Uncomment the following line to enable the pause function
 #pause 'Press [Enter] key to continue...'
 
-# Set default values for script options
+
+
+# Set default variables
 unset diff_small
 INSTALL_METHOD='default'
 PROMPTS=true
@@ -167,6 +192,8 @@ else
   TTY_AVAILABILITY='/dev/null'
 fi
 
+
+
 # Print version and exit
 version() {
   echo -e "${Purple}#########################################################################
@@ -184,7 +211,9 @@ version() {
 exit 2
 }
 
-# Function to display help information and exit
+
+
+# Display help information and exit
 help() {
   local help
   read -r -d '' help << EOM
@@ -232,8 +261,10 @@ EOM
   exit 2
 }
 
+
+
 # Parse command-line options
-options=$(getopt -o Uatyelzh --long help,fix,f2fs,version,loop,no-color: -- "$@")
+options=$(getopt -o Uatyelzhq --long help,version,quiet,fix,f2fs,no-color,loop: -- "$@")
 [ $? -eq 0 ] || {
     echo -e "${Red}Incorrect options provided"
     help
@@ -253,7 +284,7 @@ while true; do
     -q|--quiet) RSYNC_TTY=false; shift;;
     --fix) RSYNC_DELETE='--delete-before'; shift;;
     --f2fs) F2FS=true; shift;;
-    --no-color) unset White IWhite Red Blue Green Yellow Purple NC; debug 'DEBUG' '--no-color selected by user'; shift;;
+    --no-color) unset White IWhite Red Blue Green Yellow Purple NC; debug 'DEBUG' '--no-color selected by user, unsetting color variables'; shift;;
     --loop) LOOPRUN=true; IMG_FILE="$2"; shift 2;;
     --) break;;
     *) shift;;
@@ -275,7 +306,7 @@ do
   fi
 done
 
-# Check if script is running as root
+# Verify script is running as root
 if [ "$EUID" -ne 0 ]; then
   echo -e "${Red}!! THIS SCRIPT MUST BE RUNNING AS ROOT! (WITH SUDO)"
   help
@@ -283,26 +314,7 @@ fi
 
 
 
-function debug() {
-  local log_level="$1"
-  local log_message="$2"
-  if [ "$DEBUG" = true ]; then
-    if [ "$log_level" = 'BREAK' ]; then
-      echo '------------------------------------------------------------------------------' >> "$LOG_FILE"
-    else
-      if [ $log_level = 'INFO' ]; then
-        echo -e "$(date +"%Y-%m-%d %H:%M:%S") [$log_level]  - $log_message" >> "$LOG_FILE"
-      else
-        echo -e "$(date +"%Y-%m-%d %H:%M:%S") [$log_level] - $log_message" >> "$LOG_FILE"
-      fi
-    fi
-  fi
-return 0
-}
-
-
-
-# Function to loop the img file and exit
+# loop img file and exit
 function looprun() {
   if [ "$ADDED_SPACE" -ne 0 ]; then
     echo -e "${Yellow}!! ${Red}WARNING! ${Yellow}You have requested to add ${Green}${ADDED_SPACE}MiB ${Yellow}to the img file (NOT partition)"
@@ -348,7 +360,7 @@ exit 2
 
 
 
-# Function to gather device information
+# Gather device information
 function get_dev_variables() {
 
   # Run get_btrfs_variables and then exit THIS function (added space = 0)
@@ -456,7 +468,7 @@ return 0
 
 
 
-# Function to gather btrfs information
+# Gather btrfs information
 function get_btrfs_variables() {
 
   BOOT_PATH=$(cat /etc/fstab | grep 'boot' | awk '{print $2}')
@@ -490,7 +502,7 @@ return 0
 
 
 
-# Function to gather image information
+# Gather image information
 function get_img_variables() {
 
   debug 'DEBUG' "Running: stat -c %s $IMG_FILE"
@@ -581,7 +593,7 @@ return 0
 
 
 
-# Function for shared variables
+# Set shared variables
 function set_img_variables() {
 
   # Boot partition exists
@@ -659,7 +671,7 @@ return 0
 
 
 
-# Function to loop img file
+# loop img file
 function do_loop() {
 
   if [ -z "$LOOP" ]; then
@@ -681,7 +693,7 @@ return 0
 
 
 
-# Function to mount img file
+# mount img file
 function do_mount() {
 
   # Check for temp directory and create if needed
@@ -778,7 +790,7 @@ return 0
 
 
 
-# Function to check filesystem
+# Check filesystem
 function do_e2fsck() {
 
   if [ -n "$BOOT_PATH" ] && [ -n "$TMP_DIR" ] && grep -qs "${TMP_DIR}${BOOT_PATH} " /proc/mounts; then
@@ -829,7 +841,7 @@ return 0
 
 
 
-# Function to resize image
+# Resize image
 function do_resize() {
 
   # Reading offset for img root partition
@@ -987,7 +999,7 @@ return 0
 
 
 
-# Function to rsync to img file
+# rsync to img file
 function do_rsync() {
 
   echo -e "${White}## ${IWhite}Backing up files..."
@@ -1061,7 +1073,7 @@ return 0
 
 
 
-# Function to create a backup img file
+# Create a backup img file
 function make_img() {
 
   debug 'INFO' 'Running function: get_dev_variables'
@@ -1089,6 +1101,7 @@ function make_img() {
   echo -e "${Purple}# --------------------------------------------------------------------------------- #"
   echo -e "# ${IWhite}Write to logfile:              ${Green}$DEBUG ${Purple}$(printf "%+$(( COLS - 33 - $(echo ${DEBUG} | wc -m ) ))s" '#')"
   echo -e "# ${IWhite}Zoom speed requested:          ${Green}$ZOOM ${Purple}$(printf "%+$(( COLS - 33 - $(echo ${ZOOM} | wc -m ) ))s" '#')"
+  echo -e "# ${IWhite}rsync tty output:              ${Green}$RSYNC_TTY ${Purple}$(printf "%+$(( COLS - 33 - $(echo ${RSYNC_TTY} | wc -m ) ))s" '#')"
   echo -e "# ${IWhite}Autocalculate img root size:   ${Green}$AUTORESIZE_RUN ${Purple}$(printf "%+$(( COLS - 33 - $(echo ${AUTORESIZE_RUN} | wc -m ) ))s" '#')"
   echo -e "# ${IWhite}Autoexpand filesystem at boot: ${Green}$AUTOEXPAND ${Purple}$(printf "%+$(( COLS - 33 - $(echo ${AUTOEXPAND} | wc -m ) ))s" '#')"
   echo -e "# ${IWhite}Use exclude.txt:               ${Green}$EXCLUDE_FILE ${Purple}$(printf "%+$(( COLS - 33 - $(echo ${EXCLUDE_FILE} | wc -m ) ))s" '#')"
@@ -1604,7 +1617,7 @@ return 0
 
 
 
-# Function to update existing img file
+# Update existing backup img file
 function do_backup() {
 
   # Making sure img file exists
@@ -1678,6 +1691,7 @@ function do_backup() {
   echo -e "${Purple}# --------------------------------------------------------------------------------- #"
   echo -e "# ${IWhite}Write to logfile:              ${Green}$DEBUG ${Purple}$(printf "%+$(( COLS - 33 - $(echo ${DEBUG} | wc -m ) ))s" '#')"
   echo -e "# ${IWhite}Zoom speed requested:          ${Green}$ZOOM ${Purple}$(printf "%+$(( COLS - 33 - $(echo ${ZOOM} | wc -m ) ))s" '#')"
+  echo -e "# ${IWhite}rsync tty output:              ${Green}$RSYNC_TTY ${Purple}$(printf "%+$(( COLS - 33 - $(echo ${RSYNC_TTY} | wc -m ) ))s" '#')"
   echo -e "# ${IWhite}Autocalculate img root size:   ${Green}$AUTORESIZE_RUN ${Purple}$(printf "%+$(( COLS - 33 - $(echo ${AUTORESIZE_RUN} | wc -m ) ))s" '#')"
   echo -e "# ${IWhite}Autoexpand filesystem at boot: ${Green}$AUTOEXPAND ${Purple}$(printf "%+$(( COLS - 33 - $(echo ${AUTOEXPAND} | wc -m ) ))s" '#')"
   echo -e "# ${IWhite}Use exclude.txt:               ${Green}$EXCLUDE_FILE ${Purple}$(printf "%+$(( COLS - 33 - $(echo ${EXCLUDE_FILE} | wc -m ) ))s" '#')"
@@ -1786,7 +1800,7 @@ return 0
 
 
 
-# Enabling autoexpansion for Manjaro
+# Enable autoexpansion for Manjaro
 function autoexpansion_manjaro() {
   if ! [ -d "${TMP_DIR}/etc/systemd/system/basic.target.wants" ]; then
     debug 'DEBUG' "Systemd basic.target.wants directory does not exist, running: mkdir ${TMP_DIR}/etc/systemd/system/basic.target.wants"
@@ -1823,7 +1837,7 @@ return 0
 
 
 
-# Enabling autoexpansion for Armbian
+# Enable autoexpansion for Armbian
 function autoexpansion_armbian() {
   if ! test -L "${TMP_DIR}/etc/systemd/system/basic.target.wants/armbian-resize-filesystem.service"; then
     debug 'DEBUG' "Enabling systemd service by creating symlink: ln -s /lib/systemd/system/armbian-resize-filesystem.service ${TMP_DIR}/etc/systemd/system/basic.target.wants/armbian-resize-filesystem.service"
@@ -1837,7 +1851,7 @@ return 0
 
 
 
-# Enabling autoexpansion for Raspberry pi
+# Enable autoexpansion for Raspberry pi
 function autoexpansion_rpi() {
   if ! [ -d "${TMP_DIR}/etc/systemd/system/basic.target.wants" ]; then
     debug 'DEBUG' "Systemd basic.target.wants directory does not exist, running: mkdir ${TMP_DIR}/etc/systemd/system/basic.target.wants"
@@ -1897,7 +1911,7 @@ return 0
 
 
 
-# Enabling autoexpansion for ArchLinuxArm
+# Enable autoexpansion for ArchLinuxArm
 function autoexpansion_arch() {
   if ! [ -d "${TMP_DIR}/etc/systemd/system/basic.target.wants" ]; then
     debug 'DEBUG' "Systemd basic.target.wants directory does not exist, running: mkdir ${TMP_DIR}/etc/systemd/system/basic.target.wants"
@@ -1956,7 +1970,7 @@ return 0
 
 
 
-# Function to print result
+# Print result
 function print_result() {
 
   declare -i AFTER_SIZE=$(stat -c %s "$IMG_FILE")

--- a/shrink-backup
+++ b/shrink-backup
@@ -2331,7 +2331,7 @@ function print_result() {
   debug 'BREAK'
 
   # Make sure boot partition was not unmounted during backup
-  if grep -q 'boot' /etc/fstab && ! mount --fake | grep -q "$IMG_DEV_BOOT_PATH"; then
+  if grep -q 'boot' /etc/fstab && ! mount --fake | grep -q "$LOCAL_DEV_BOOT_PATH"; then
     debug 'ERROR' "Boot partition ($IMG_DEV_BOOT_PATH) became unmounted during backup"
     echo -e "${Red}!! BOOT PARTITION BECAME UNMOUNTED DURING BACKUP!!"
     echo -e "${Red}!! RE-RUN SHRINK-BACKUP WITH -U OPTION!!"

--- a/shrink-backup
+++ b/shrink-backup
@@ -22,7 +22,9 @@ function debug() {
       echo '-------------------------------------------------------------------------------------' >> "$LOG_FILE"
     else
       if [ $log_level = 'INFO' ]; then
-        echo -e "$(date +"%Y-%m-%d %H:%M:%S") [$log_level]  - $log_message" >> "$LOG_FILE"
+        echo -e "$(date +"%Y-%m-%d %H:%M:%S") [$log_level]    - $log_message" >> "$LOG_FILE"
+      elif [ $log_level = 'ERROR' ]; then
+        echo -e "$(date +"%Y-%m-%d %H:%M:%S") [$log_level]   - $log_message" >> "$LOG_FILE"
       else
         echo -e "$(date +"%Y-%m-%d %H:%M:%S") [$log_level] - $log_message" >> "$LOG_FILE"
       fi
@@ -2329,7 +2331,7 @@ function print_result() {
   debug 'BREAK'
 
   # Make sure boot partition was not unmounted during backup
-  if grep -q 'boot' /etc/fstab && ! mount --fake | grep -q 'boot'; then
+  if grep -q 'boot' /etc/fstab && ! mount --fake | grep -q "$IMG_DEV_BOOT_PATH"; then
     debug 'ERROR' 'Boot partition became unmounted during backup'
     echo -e "${Red}!! BOOT PARTITION BECAME UNMOUNTED DURING BACKUP!!"
     echo -e "${Red}!! RE-RUN SHRINK-BACKUP WITH -U OPTION!!"

--- a/shrink-backup
+++ b/shrink-backup
@@ -4,7 +4,7 @@
 # Version 1.3-beta
 # Backup tool for creating and updating .img files (with autoexpansion function) on various linux operating systems
 #
-#    Copyright (c) 2024, Marcus Johansson
+#    Copyright (c) 2025, Marcus Johansson
 #    https://github.com/UnconnectedBedna/shrink-backup
 #    All rights reserved.
 #
@@ -203,8 +203,9 @@ AUTORESIZE_WARNING=false
 ZOOM=false
 LOOPRUN=false
 CHROOTRUN=false
-RSYNC_DELETE='--delete'
-RSYNC_TTY=true
+RSYNC_DELETE='--delete' # gets set to --delete-before if --fix is selected
+RSYNC_TTY=true # gets set to false if -q|--quiet is selected
+RSYNC_CUSTOM=false
 F2FS_CONVERSION=false
 BTRFS_CONVERSION=false
 #STARTLINE="$0 $*" # will produce double // if script is in $PATH
@@ -267,6 +268,7 @@ Usage: ${Green}sudo $(basename "$0") [options] imagefile.img [extra space (MiB)]
                    Shrink if partition is >=512MiB bigger than autocalculated recommended minimum
   ${Green}-t             ${IWhite}Use exclude.txt in same folder as script to set excluded directories
                    One directory per line: "/dir" or "/dir/*" to only exclude contents
+                   Wildcards work, f.ex "/dir*" will eclude all directories starting with "/dir"
   ${Green}-y             ${IWhite}Disable prompts in script (please use this option with care!)
   ${Green}-e             ${IWhite}Disable autoexpansion on root filesystem when image is booted
   ${Green}-l             ${IWhite}Write debug messages to logfile shrink-backup.log located in same directory as script
@@ -275,6 +277,7 @@ Usage: ${Green}sudo $(basename "$0") [options] imagefile.img [extra space (MiB)]
   ${Green}-q --quiet     ${IWhite}Do not print rsync copy process
   ${Green}--no-color     ${IWhite}Run script without color formatted text
   ${Green}--fix          ${IWhite}Try to fix the img file if -a fails with a "broken pipe" error
+  ${Green}--rsync        ${IWhite}Define custom rsync line manually. Will print rsync line for user to edit
   ${Green}--loop [img]   ${IWhite}Loop img file and exit, works in combination with -l & -z
                    If optional [extra space] is defined, the img file will be extended with the amount before looping
                    NOTE that only the file gets truncated, no partitions
@@ -307,7 +310,7 @@ EOM
 
 
 # Parse command-line options
-options=$(getopt -o Uatyelzhq --long help,version,quiet,fix,f2fs,no-color,loop,chroot: -- "$@")
+options=$(getopt -o Uatyelzhq --long help,version,quiet,fix,f2fs,no-color,rsync,loop,chroot: -- "$@")
 [ $? -eq 0 ] || {
     echo -e "${Red}Incorrect options provided"
     help
@@ -328,6 +331,7 @@ while true; do
     --fix) RSYNC_DELETE='--delete-before'; shift;;
     --f2fs) F2FS_CONVERSION=true; shift;;
     --no-color) unset White IWhite Red Blue Green Yellow Purple NC; COLORS=false; debug 'DEBUG' '--no-color selected by user, unsetting color variables'; shift;;
+    --rsync) RSYNC_CUSTOM=true; shift;;
     --loop) LOOPRUN=true; IMG_FILE="$3"; shift;;
     --chroot) CHROOTRUN=true; IMG_FILE="$2"; shift;;
     --) break;;
@@ -1056,15 +1060,6 @@ return 0
 # Mount img file
 function do_mount() {
 
-  # Check for temp directory and create if needed
-  if ! [ -d "$TMP_DIR" ]; then
-    echo -e "${White}## ${IWhite}Creating temp directory..."
-    $SLEEPING
-    debug 'INFO' 'Creating temp directory'
-    debug 'DEBUG' "Running: mktemp -d -t backup-XXX"
-    TMP_DIR=$(mktemp -d -t backup-XXX)
-    debug 'DEBUG' "TMP_DIR=$TMP_DIR"
-  fi
   partprobe "$LOOP"
 
   # ext4 & f2fs
@@ -1422,26 +1417,9 @@ function do_rsync() {
   fi
   IMG_PATH=$(dirname "$IMG_FILE")
   debug 'DEBUG' "Backing up to ${IMG_PATH}${IMG_FILE}"
-  debug 'INFO' 'Creating temporary file to store rsync output'
-  debug 'DEBUG' 'Running: mktemp -t rsync-XXX'
-  tmp_file=$(mktemp -t rsync-XXX)
-  debug 'DEBUG' "tmp_file=$tmp_file"
 
-  if [ "$EXCLUDE_FILE" = true ]; then
-    debug 'DEBUG' "Running: rsync -ahvHAX --exclude-from="$EXCLUDE_FILE_LOCATION" --exclude={${IMG_PATH}/*,${TMP_DIR},${tmp_file},${BOOT_PATH}/shrink-backup.lock} --info=progress2 --stats "$RSYNC_DELETE" --force --partial --delete-excluded --timeout=30 / $TMP_DIR"
-    if [ "$RSYNC_TTY" = true ]; then
-      rsync -ahvHAX --exclude-from="$EXCLUDE_FILE_LOCATION" --exclude={${IMG_PATH}/*,${TMP_DIR},${tmp_file},${BOOT_PATH}/shrink-backup.lock} --info=progress2 --stats "$RSYNC_DELETE" --force --partial --delete-excluded --timeout=30 / "$TMP_DIR" 2>&1 | tee "$TTY_AVAILABILITY" > "$tmp_file"
-    else
-      rsync -ahvHAX --exclude-from="$EXCLUDE_FILE_LOCATION" --exclude={${IMG_PATH}/*,${TMP_DIR},${tmp_file},${BOOT_PATH}/shrink-backup.lock} --info=progress2 --stats "$RSYNC_DELETE" --force --partial --delete-excluded --timeout=30 / "$TMP_DIR" 2>&1 | tee /dev/null > "$tmp_file"
-    fi
-  else
-    debug 'DEBUG' "Running: rsync -ahvHAX --exclude={/lost+found,/proc/*,/sys/*,/dev/*,/tmp/*,/run/*,/mnt/*,/media/*,/var/swap,/snap/*,${IMG_PATH}/*,${BOOT_PATH}/shrink-backup.lock} --info=progress2 --stats "$RSYNC_DELETE" --force --partial --delete-excluded --timeout=30 / $TMP_DIR"
-    if [ "$RSYNC_TTY" = true ]; then
-      rsync -ahvHAX --exclude={/lost+found,/proc/*,/sys/*,/dev/*,/tmp/*,/run/*,/mnt/*,/media/*,/var/swap,/snap/*,${IMG_PATH}/*,${BOOT_PATH}/shrink-backup.lock} --info=progress2 --stats "$RSYNC_DELETE" --force --partial --delete-excluded --timeout=30 / "$TMP_DIR" 2>&1 | tee "$TTY_AVAILABILITY" > "$tmp_file"
-    else
-      rsync -ahvHAX --exclude={/lost+found,/proc/*,/sys/*,/dev/*,/tmp/*,/run/*,/mnt/*,/media/*,/var/swap,/snap/*,${IMG_PATH}/*,${BOOT_PATH}/shrink-backup.lock} --info=progress2 --stats "$RSYNC_DELETE" --force --partial --delete-excluded --timeout=30 / "$TMP_DIR" 2>&1 | tee /dev/null > "$tmp_file"
-    fi
-  fi
+  # Run rsync
+  eval "$RSYNC_LINE"
 
   # Get the exit status of rsync from PIPESTATUS
   if [ "${PIPESTATUS[0]}" -ne 0 ] && [ "${PIPESTATUS[0]}" -ne 23 ]; then # code 23 = rsync warning: some files vanished before they could be transferred (code 24) at main.c
@@ -1568,6 +1546,10 @@ function make_img() {
     echo -e "# ${Yellow}Converting filesystem into ${Green}f2fs ${Yellow}on img file ${Purple}$(printf "%+$(( COLS - 46 ))s" '#')"
     echo -e "# ${Yellow}Autoexpand filesystem at boot not available for ${Green}f2fs ${Purple}$(printf "%+$(( COLS - 55 ))s" '#')"
   fi
+  if [ "$RSYNC_CUSTOM" = true ]; then
+    echo -e "# ${IWhite}Custom rsync line: ${Purple}$(printf "%+$(( COLS - 21 ))s" '#')"
+    echo -e "  ${Green}$RSYNC_CUSTOM_LINE"
+  fi
   echo -e "${Purple}# $(printf %$(( COLS - 4 ))s | tr ' ' '-') #"
   echo -e "# ${IWhite}Write to logfile:              ${Green}$DEBUG ${Purple}$(printf "%+$(( COLS - 33 - $(echo ${DEBUG} | wc -m ) ))s" '#')"
   echo -e "# ${IWhite}Zoom speed requested:          ${Green}$ZOOM ${Purple}$(printf "%+$(( COLS - 33 - $(echo ${ZOOM} | wc -m ) ))s" '#')"
@@ -1627,13 +1609,11 @@ function make_img() {
         read -r -p '## Do you want to continue? [y/n] ' input
       fi
       case $input in
-        [Yy]) break;;
+        [Yy]) debug 'INFO' 'Y or y pressed to confirm'; debug 'BREAK'; break;;
         [Nn]) echo -e "${Red}!! Aborting..."; exit 4;;
         *) echo -e "${Yellow}!! ${Red}ERROR! ${Yellow}Please enter ${Green}'y' ${Yellow}or ${Green}'n'${Yellow}"; debug 'WARNING' "ERROR, please enter 'y' or 'n'";;
       esac
     done
-    debug 'INFO' 'Y or y pressed to confirm'
-    debug 'BREAK'
 
     if test -f "$IMG_FILE"; then
       debug 'WARNING' "$IMG_FILE ALREADY EXISTS!"
@@ -1648,12 +1628,11 @@ function make_img() {
           read -r -p '## Do you want to overwrite? [y/n] ' input
         fi
         case $input in
-          [Yy]) break;;
+          [Yy]) debug 'WARNING' 'Overwrite confirmed by user'; break;;
           [Nn]) echo -e "${Red}!! Aborting..."; exit 4;;
           *) echo -e "${Yellow}!! ${Red}ERROR! ${Yellow}Please enter ${Green}'y' ${Yellow}or ${Green}'n'${Yellow}"; debug 'WARNING' "ERROR, please enter 'y' or 'n'";;
         esac
       done
-      debug 'WARNING' 'Overwrite confirmed by user'
     fi
   else
     echo -e "${Purple}${BREAK}${IWhite}"
@@ -1841,16 +1820,6 @@ function make_img() {
     debug 'BREAK'
     debug 'DEBUG' "Running: mkfs.btrfs -f -m single -L $LABEL -v $IMG_DEV_ROOT_PATH\n$output\n-------------------------------------------------------------------------------------"
 
-    # Check for temp directory and create if needed
-    if ! [ -d "$TMP_DIR" ]; then
-      echo -e "${White}## ${IWhite}Creating temp directory..."
-      $SLEEPING
-      debug 'INFO' 'Creating temp directory'
-      debug 'DEBUG' "Running: mktemp -d -t backup-XXX"
-      TMP_DIR=$(mktemp -d -t backup-XXX)
-      debug 'DEBUG' "TMP_DIR=$TMP_DIR"
-    fi
-
     # Mount btrfs filesystem and create volumes
     echo -e "${White}## ${IWhite}Creating btrfs subvolumes..."
     $SLEEPING
@@ -1976,6 +1945,10 @@ function update_img() {
   if [ "$RSYNC_DELETE" = '--delete-before' ]; then
     echo -e "# ${Green}--fix ${IWhite}option selected, rsync will delete files on img before copy ${Purple}$(printf "%+$(( COLS - 68 ))s" '#')"
     debug 'DEBUG' '--fix selected by user, rsync deleting files before copy'
+  fi
+  if [ "$RSYNC_CUSTOM" = true ]; then
+    echo -e "# ${IWhite}Custom rsync line: ${Purple}$(printf "%+$(( COLS - 21 ))s" '#')"
+    echo -e "  ${Green}$RSYNC_CUSTOM_LINE"
   fi
   echo -e "${Purple}# $(printf %$(( COLS - 4 ))s | tr ' ' '-') #"
   echo -e "# ${IWhite}Write to logfile:              ${Green}$DEBUG ${Purple}$(printf "%+$(( COLS - 33 - $(echo ${DEBUG} | wc -m ) ))s" '#')"
@@ -2404,7 +2377,7 @@ if [ "$UPDATE" = false ] && [ -z "$ADDED_SPACE" ]; then
   else
     read -r -p '## Please input requested [extra space] in MiB (0 is valid): ' ADDED_SPACE
   fi
-  debug 'USER_INPUT' "User requested ${ADDED_SPACE}MiB as ADDED_SPACE"
+  debug 'DEBUG' "User requested ${ADDED_SPACE}MiB as ADDED_SPACE"
 fi
 
 # Regular expression for whole numbers
@@ -2426,7 +2399,7 @@ if ! [[ "$ADDED_SPACE" =~ $RE ]]; then
     read ADDED_SPACE
     (( COUNTER++ ))
     #(( COUNTER += 1 ))
-    debug 'USER_INPUT' "User requested ${ADDED_SPACE}MiB as ADDED_SPACE"
+    debug 'DEBUG' "User requested ${ADDED_SPACE}MiB as ADDED_SPACE"
   done
   typeset -i ADDED_SPACE
 fi
@@ -2571,6 +2544,7 @@ if [ "$DEBUG" = true ]; then
   debug 'DEBUG' "EXCLUDE_FILE=$EXCLUDE_FILE"
   debug 'DEBUG' "AUTOEXPAND=$AUTOEXPAND"
   debug 'DEBUG' "RSYNC_DELETE=$RSYNC_DELETE"
+  debug 'DEBUG' "RSYNC_CUSTOM=$RSYNC_CUSTOM"
   debug 'DEBUG' "F2FS_CONVERSION=$F2FS_CONVERSION"
   debug 'DEBUG' "TTY_AVAILABILITY=$TTY_AVAILABILITY"
   debug 'DEBUG' "ADDED_SPACE=$ADDED_SPACE"
@@ -2589,6 +2563,48 @@ if [ "$EXCLUDE_FILE" = true ]; then
 else
   debug 'INFO' '-t NOT selected by user, using default exclude directories'
 fi
+
+# Set default RSYNC_LINE
+IMG_PATH=$(dirname "$IMG_FILE")
+debug 'INFO' 'Creating temp directory'
+debug 'DEBUG' "Running: mktemp -d -t backup-XXX"
+TMP_DIR=$(mktemp -d -t backup-XXX)
+debug 'DEBUG' "TMP_DIR=$TMP_DIR"
+debug 'INFO' 'Creating temp file to store rsync output'
+debug 'DEBUG' 'Running: mktemp -t rsync-XXX'
+tmp_file=$(mktemp -t rsync-XXX)
+debug 'DEBUG' "tmp_file=$tmp_file"
+if [ "$RSYNC_TTY" = false ]; then
+  RSYNC_PATHS="/ $TMP_DIR 2>&1 | tee /dev/null > $tmp_file"
+else
+  RSYNC_PATHS="/ $TMP_DIR 2>&1 | tee $TTY_AVAILABILITY > $tmp_file"
+fi
+debug 'DEBUG' "RSYNC_PATHS=$RSYNC_PATHS"
+
+if [ "$EXCLUDE_FILE" = true ]; then
+  RSYNC_LINE="rsync -ahvHAX --exclude-from=$EXCLUDE_FILE_LOCATION --exclude={${IMG_PATH}/*,${TMP_DIR},${tmp_file},${BOOT_PATH}/shrink-backup.lock} --info=progress2 --stats $RSYNC_DELETE --force --partial --delete-excluded --timeout=30"
+else
+  RSYNC_LINE="rsync -ahvHAX --exclude={/lost+found,/proc/*,/sys/*,/dev/*,/tmp/*,/run/*,/mnt/*,/media/*,/var/swap,/snap/*,${IMG_PATH}/*,${BOOT_PATH}/shrink-backup.lock} --info=progress2 --stats $RSYNC_DELETE --force --partial --delete-excluded --timeout=30"
+fi
+debug 'DEBUG' "RSYNC_LINE=$RSYNC_LINE"
+
+# If --rsync is selected, ask for user configuration
+if [ "$RSYNC_CUSTOM" = true ]; then
+  echo -e "${Yellow}## Custom rsync line option selected"
+  echo -e "${White}## ${IWhite}Default rsync line: ${Green}${RSYNC_LINE}"
+  echo -e "${White}## ${IWhite}Edit line to use in script ${Yellow}(press ctrl+c to abort)${NC}"
+  printf %${COLUMNS}s | tr ' ' '#'
+
+  read -e -i "$RSYNC_LINE" input
+  RSYNC_CUSTOM_LINE="$input"
+  RSYNC_LINE="$input"
+  debug 'DEBUG' "RSYNC_CUSTOM_LINE=$RSYNC_CUSTOM_LINE"
+fi
+
+# Add RSYNC_PATHS to RSYNC_LINE
+debug 'INFO' 'Combining RSYNC_LINE & RSYNC_PATHS'
+RSYNC_LINE="$(echo -e $RSYNC_LINE $RSYNC_PATHS)"
+debug 'DEBUG' "RSYNC_LINE=$RSYNC_LINE"
 
 # Check dependencies
 debug 'INFO' 'Running function: check_dependencies'

--- a/shrink-backup
+++ b/shrink-backup
@@ -2054,7 +2054,7 @@ else
 fi
 
 # Check if the image file has the correct extension
-if [[ "$IMG_FILE" != *.img ]]; then
+if [ "$LOOPRUN" = false ] && [[ "$IMG_FILE" != *.img ]]; then
   echo -e "${Red}!! ERROR! ${Yellow}File must have ${Green}.img ${Yellow}extension"
   debug 'ERROR' 'File must have .img extension, exit 3'
   exit 3

--- a/shrink-backup
+++ b/shrink-backup
@@ -2332,9 +2332,11 @@ function print_result() {
 
   # Make sure boot partition was not unmounted during backup
   if grep -q 'boot' /etc/fstab && ! mount --fake | grep -q "$IMG_DEV_BOOT_PATH"; then
-    debug 'ERROR' 'Boot partition became unmounted during backup'
+    debug 'ERROR' "Boot partition ($IMG_DEV_BOOT_PATH) became unmounted during backup"
     echo -e "${Red}!! BOOT PARTITION BECAME UNMOUNTED DURING BACKUP!!"
     echo -e "${Red}!! RE-RUN SHRINK-BACKUP WITH -U OPTION!!"
+    echo -e "$Yellow## shrink-backup will mount the partition for you if you don't do so yourself"
+    echo -e "$Yellow sudo ./shrink-backup -Ul $IMG_FILE"
   fi
 return 0
 }

--- a/shrink-backup
+++ b/shrink-backup
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # shrink-backup
-# Version 1.2
+# Version 1.3-beta
 # Backup tool for creating and updating .img files (with autoexpansion function) on various linux operating systems
 #
 #    Copyright (c) 2024, Marcus Johansson
@@ -168,7 +168,7 @@ fi
 version() {
   echo -e "${Purple}#########################################################################
 #                                                                       #
-# ${Green}shrink-backup version 1.2                                             ${Purple}#
+# ${Green}shrink-backup version 1.3-beta                                        ${Purple}#
 #                                                                       #
 # ${IWhite}Copyright (c) 2024, Marcus Johansson                                  ${Purple}#
 # ${White}https://github.com/UnconnectedBedna/shrink-backup                     ${Purple}#

--- a/shrink-backup
+++ b/shrink-backup
@@ -1204,7 +1204,7 @@ function make_img() {
   fi
   $SLEEPING
   debug 'INFO' 'Using dd to create bootsector'
-  if ! output=$(dd bs=512 count=$LOCAL_DDBOOTSECTOR if="$LOCAL_DEV_PATH" of="$IMG_FILE" conv=noerror,sync status=progress 2>&1 | tee "$TTY_AVAILABILITY"); then
+  if ! output=$(dd bs=512 count=$LOCAL_DDBOOTSECTOR if="$LOCAL_DEV_PATH" of="$IMG_FILE" conv=noerror,fsync status=progress 2>&1 | tee "$TTY_AVAILABILITY") && sync; then
     echo -e "${Yellow}$output\n${Red}!! DD TO LOCAL_BOOTSECTOR FAILED!!!"
     debug 'BREAK'
     debug 'ERROR' "DD TO LOCAL_BOOTSECTOR FAILED:\n$output\n------------------------------------------------------------------------------"

--- a/shrink-backup
+++ b/shrink-backup
@@ -228,7 +228,7 @@ EOM
 }
 
 # Parse command-line options
-options=$(getopt -o Uatyelzh --long help,fix,f2fs,version,loop: -- "$@")
+options=$(getopt -o Uatyelzh --long help,fix,f2fs,version,loop,no-color: -- "$@")
 [ $? -eq 0 ] || {
     echo -e "${Red}Incorrect options provided"
     help
@@ -247,6 +247,7 @@ while true; do
     -z) ZOOM=true; shift;;
     --fix) RSYNC_DELETE='--delete-before'; shift;;
     --f2fs) F2FS=true; shift;;
+    --no-color) unset White IWhite Red Blue Green Yellow Purple NC; shift;;
     --loop) LOOPRUN=true; IMG_FILE="$2"; shift 2;;
     --) break;;
     *) shift;;
@@ -268,9 +269,9 @@ do
   fi
 done
 
-# Check if script is run as root
+# Check if script is running as root
 if [ "$EUID" -ne 0 ]; then
-  echo -e "${Red}!! THIS SCRIPT MUST BE RUN AS ROOT! (WITH SUDO)"
+  echo -e "${Red}!! THIS SCRIPT MUST BE RUNNING AS ROOT! (WITH SUDO)"
   help
 fi
 
@@ -357,8 +358,8 @@ function get_dev_variables() {
   if grep -q 'boot' /etc/fstab; then
     debug 'INFO' 'Separate boot partition detected'
     #LOCAL_DEV_BOOT_PATH=$(lsblk -lpo mountpoint,path | grep 'boot' | awk '{print $2}')
-    LOCAL_DEV_BOOT_PATH=$(mount | grep 'boot' | awk '{print $1}')
-    LOCAL_DEV_ROOT_PATH=$(mount | grep ' / ' | awk '{print $1}')
+    LOCAL_DEV_BOOT_PATH=$(mount --fake | grep 'boot' | awk '{print $1}')
+    LOCAL_DEV_ROOT_PATH=$(mount --fake | grep ' / ' | awk '{print $1}')
     debug 'DEBUG' "LOCAL_DEV_BOOT_PATH=$LOCAL_DEV_BOOT_PATH | LOCAL_DEV_ROOT_PATH=$LOCAL_DEV_ROOT_PATH"
     LOCAL_BOOT_UUID=$(lsblk -no uuid "$LOCAL_DEV_BOOT_PATH")
     LOCAL_ROOT_UUID=$(lsblk -no uuid "$LOCAL_DEV_ROOT_PATH")
@@ -368,7 +369,7 @@ function get_dev_variables() {
     debug 'DEBUG' "BOOT_PATH=$BOOT_PATH"
   else
     debug 'INFO' 'No boot partition detected'
-    LOCAL_DEV_ROOT_PATH=$(mount | grep ' / ' | awk '{print $1}')
+    LOCAL_DEV_ROOT_PATH=$(mount --fake | grep ' / ' | awk '{print $1}')
     debug 'DEBUG' "LOCAL_DEV_ROOT_PATH=$LOCAL_DEV_ROOT_PATH"
     LOCAL_ROOT_UUID=$(lsblk -no uuid "$LOCAL_DEV_ROOT_PATH")
     LOCAL_ROOT_PARTUUID=$(lsblk -no partuuid "$LOCAL_DEV_ROOT_PATH")
@@ -745,7 +746,7 @@ function do_mount() {
 
   # Mount boot partition if exists
   if [ -n "$BOOT_PATH" ]; then
-    if ! mount | grep -q 'boot'; then
+    if ! mount --fake | grep -q 'boot'; then
       echo -e "${Red}!! Boot found in fstab but partition not mounted, please mount and retry script!!!"
       debug 'ERROR' 'Boot found in fstab but partition not mounted, exit 1'
       exit 1
@@ -1846,7 +1847,7 @@ LOCAL_DEV_PTUUID=\$(lsblk -no mountpoint,ptuuid | grep '/ ' | awk '{print \$2}')
 LOCAL_DEV_PATH=\$(lsblk -no ptuuid,type,path | grep "\$LOCAL_DEV_PTUUID" | grep 'disk' | awk '{print \$3}')
 LOCAL_ROOT_PARTN=\$(parted -sm "\$LOCAL_DEV_PATH" print | tail -1 | cut -d : -f 1)
 #LOCAL_DEV_ROOT_PATH=\$(lsblk -no mountpoint,path | grep '/ ' | awk '{print \$2}')
-LOCAL_DEV_ROOT_PATH=\$(mount | grep ' / ' | awk '{print \$1}')
+LOCAL_DEV_ROOT_PATH=\$(mount --fake | grep ' / ' | awk '{print \$1}')
 LOCAL_ROOT_START=\$(fdisk -lo start "\$LOCAL_DEV_PATH" | tail -1 | awk '{print \$1}') # blocks, 512B block size
 LOCAL_ROOT_START=\$(( LOCAL_ROOT_START * 512 )) # bytes
 
@@ -1906,7 +1907,7 @@ LOCAL_DEV_PTUUID=\$(lsblk -no mountpoint,ptuuid | grep '/ ' | awk '{print \$2}')
 LOCAL_DEV_PATH=\$(lsblk -no ptuuid,type,path | grep "\$LOCAL_DEV_PTUUID" | grep 'disk' | awk '{print \$3}')
 LOCAL_ROOT_PARTN=\$(parted -sm "\$LOCAL_DEV_PATH" print | tail -1 | cut -d : -f 1)
 #LOCAL_DEV_ROOT_PATH=\$(lsblk -no mountpoint,path | grep '/ ' | awk '{print \$2}')
-LOCAL_DEV_ROOT_PATH=\$(mount | grep ' / ' | awk '{print \$1}')
+LOCAL_DEV_ROOT_PATH=\$(mount --fake | grep ' / ' | awk '{print \$1}')
 LOCAL_ROOT_START=\$(fdisk -lo start "\$LOCAL_DEV_PATH" | tail -1 | awk '{print \$1}') # blocks, 512B block size
 LOCAL_ROOT_START=\$(( LOCAL_ROOT_START * 512 )) # bytes
 
@@ -1936,6 +1937,9 @@ function print_result() {
 
   echo -e "${White}## ${Green}Backup done."
   echo -e "${Purple}${BREAK}"
+
+  echo -e "## ${IWhite}Backup location: ${Green}${IMG_FILE} ${Purple}$(printf "%+$(( COLS - 20 - $(echo ${IMG_FILE} | wc -m ) ))s" '#')"
+
   echo -e "## ${IWhite}Write to logfile: ${Green}$DEBUG ${Purple}$(printf "%+$(( COLS - 21 - $(echo ${DEBUG} | wc -m ) ))s" '#')"
   echo -e "## ${IWhite}Autoexpand filesystem at boot: ${Green}$AUTOEXPAND ${Purple}$(printf "%+$(( COLS - 34 - $(echo ${AUTOEXPAND} | wc -m ) ))s" '#')"
   echo -e "## ${IWhite}Use exclude.txt: ${Green}$EXCLUDE_FILE ${Purple}$(printf "%+$(( COLS - 20 - $(echo ${EXCLUDE_FILE} | wc -m ) ))s" '#')"
@@ -1944,18 +1948,27 @@ function print_result() {
   if [ "$UPDATE" != true ]; then
     if [ "$AUTORESIZE_RUN" = true ]; then
       print_temp="$(( LOCAL_AUTORESIZE_MIN / 1024 / 1024 ))"
-      echo -e "## ${Green}${IMG_FILE} ${IWhite}is ${Green}${AFTER_SIZE}MiB ${IWhite}with a ${Green}root partition ${IWhite}of ${Green}${print_temp}MiB ${Purple}$(printf "%+$(( COLS - 37 - $(echo ${IMG_FILE} | wc -m ) - $(echo ${AFTER_SIZE} | wc -m ) - $(echo ${print_temp} | wc -m ) ))s" '#')"
+      #echo -e "## ${Green}${IMG_FILE} ${IWhite}is ${Green}${AFTER_SIZE}MiB ${IWhite}with a ${Green}root partition ${IWhite}of ${Green}${print_temp}MiB ${Purple}$(printf "%+$(( COLS - 37 - $(echo ${IMG_FILE} | wc -m ) - $(echo ${AFTER_SIZE} | wc -m ) - $(echo ${print_temp} | wc -m ) ))s" '#')"
+
+      echo -e "## ${IWhite}Backup size: ${Green}${AFTER_SIZE}MiB ${IWhite}with a ${Green}root partition ${IWhite}of ${Green}${print_temp}MiB ${Purple}$(printf "%+$(( COLS - 49 - $(echo ${AFTER_SIZE} | wc -m ) - $(echo ${print_temp} | wc -m ) ))s" '#')"
+
       debug 'INFO' "$IMG_FILE is ${AFTER_SIZE}MiB with a root partition of $(( LOCAL_AUTORESIZE_MIN / 1024 / 1024 ))MiB"
     else
       print_temp="$(( ADDED_SPACE / 1024 / 1024 ))"
-      echo -e "## ${Green}$IMG_FILE ${IWhite}is ${Green}${AFTER_SIZE}MiB ${IWhite}with ${Green}${print_temp}MiB [extra space] ${IWhite}included ${Purple}$(printf "%+$(( COLS - 40 - $(echo ${IMG_FILE} | wc -m ) - $(echo ${AFTER_SIZE} | wc -m ) - $(echo ${print_temp} | wc -m ) ))s" '#')"
+      #echo -e "## ${Green}$IMG_FILE ${IWhite}is ${Green}${AFTER_SIZE}MiB ${IWhite}with ${Green}${print_temp}MiB [extra space] ${IWhite}included ${Purple}$(printf "%+$(( COLS - 40 - $(echo ${IMG_FILE} | wc -m ) - $(echo ${AFTER_SIZE} | wc -m ) - $(echo ${print_temp} | wc -m ) ))s" '#')"
+
+      echo -e "## ${IWhite}Backup size: ${Green}${AFTER_SIZE}MiB ${IWhite}with ${Green}${print_temp}MiB [extra space] ${IWhite}included ${Purple}$(printf "%+$(( COLS - 40 - $(echo ${AFTER_SIZE} | wc -m ) - $(echo ${print_temp} | wc -m ) ))s" '#')"
+
       debug 'INFO' "$IMG_FILE is ${AFTER_SIZE}MiB with $(( ADDED_SPACE / 1024 / 1024 ))MiB [extra space] included"
     fi
     debug 'INFO' 'Img file created'
 
   # Updated backup
   else
-    echo -e "## ${Green}$IMG_FILE ${IWhite}is ${Green}${AFTER_SIZE}MiB ${Purple}$(printf "%+$(( COLS - 9 - $(echo ${IMG_FILE} | wc -m ) - $(echo ${AFTER_SIZE} | wc -m ) ))s" '#')"
+    #echo -e "## ${Green}$IMG_FILE ${IWhite}is ${Green}${AFTER_SIZE}MiB ${Purple}$(printf "%+$(( COLS - 9 - $(echo ${IMG_FILE} | wc -m ) - $(echo ${AFTER_SIZE} | wc -m ) ))s" '#')"
+
+    echo -e "## ${IWhite}Backup size: ${Green}${AFTER_SIZE}MiB ${Purple}$(printf "%+$(( COLS - 20 - $(echo ${AFTER_SIZE} | wc -m ) ))s" '#')"
+
     debug 'INFO' "$IMG_FILE is ${AFTER_SIZE}MiB"
     debug 'INFO' 'Img file updated'
   fi
@@ -2066,20 +2079,21 @@ fi
 echo -e "${White}## ${IWhite}Scanning filesystem and calculating..."
 
 # Make sure boot is mounted if it exists in fstab
-if grep -q 'boot' /etc/fstab && ! mount | grep -q 'boot'; then
+if grep -q 'boot' /etc/fstab && ! mount --fake | grep -q 'boot'; then
   echo -e "${Red}!! Boot found in fstab but partition not mounted, please mount and retry script!!!"
   debug 'ERROR' 'Boot found in fstab but partition not mounted, exit 3'
   exit 3
 fi
 
 # Check what filesystem root is using and set LOCAL_DEV_PATH & PARTITION_TABLE
-FSTYPE="$(mount | grep ' / ' | awk '{print $5}')"
+FSTYPE="$(mount --fake | grep ' / ' | awk '{print $5}')"
 debug 'INFO' "$FSTYPE root filesystem detected"
 debug 'DEBUG' "FSTYPE=$FSTYPE"
 if [ "$FSTYPE" == 'ext4' ] || [ "$FSTYPE" == 'f2fs' ]; then
   LOCAL_DEV_PTUUID=$(lsblk -no mountpoint,ptuuid | grep '/ ' | awk '{print $2}')
 else
-  LOCAL_DEV_PTUUID=$(lsblk -no fsroots,ptuuid | grep '/ ' | awk '{print $2}')
+  #LOCAL_DEV_PTUUID=$(lsblk -no fsroots,ptuuid | grep '/ ' | awk '{print $2}')
+  LOCAL_DEV_PTUUID=$(lsblk -no path,ptuuid $(mount --fake | grep ' / ' | awk '{print $1}') | awk '{print $2}')
 fi
 LOCAL_DEV_PATH=$(lsblk -no ptuuid,type,path | grep "$LOCAL_DEV_PTUUID" | grep 'disk' | awk '{print $3}' | head -1)
 debug 'DEBUG' "LOCAL_DEV_PTUUID=$LOCAL_DEV_PTUUID | LOCAL_DEV_PATH=$LOCAL_DEV_PATH"
@@ -2133,7 +2147,7 @@ fi
 if [ "$EXCLUDE_FILE" = true ]; then
   debug 'INFO' "-f selected by user, using $EXCLUDE_FILE_LOCATION"
   if ! [ -f "$EXCLUDE_FILE_LOCATION" ]; then
-    echo -e "${Red}!! ERROR! ${Green}-f selected but $EXCLUDE_FILE_LOCATION ${Yellow}does not exist!"
+    echo -e "${Red}!! ERROR! ${Green}-f selected but ${Yellow}$EXCLUDE_FILE_LOCATION does not exist!"
     debug 'ERROR' "$EXCLUDE_FILE_LOCATION does not exist, exit 3"
     exit 3
   fi

--- a/shrink-backup
+++ b/shrink-backup
@@ -1146,7 +1146,7 @@ function do_e2fsck() {
     $SLEEPING
 
     # Remounting if autoexpansion is requested
-    if [ "$AUTOEXPAND" = true ]; then
+    if [ "$AUTOEXPAND" = true ] && [ "$OS" != 'unknown' ]; then
       echo -e "${White}## ${IWhite}Remounting for autoexpansion..."
       debug 'INFO' 'Remounting for autoexpansion function'
       debug 'INFO' 'Running function: do_mount'
@@ -2298,6 +2298,13 @@ function print_result() {
   echo -e "${Purple}${BREAK}"
   debug 'INFO' 'Backup done'
   debug 'BREAK'
+  
+  # Make sure boot partition was not unmounted during backup
+  if grep -q 'boot' /etc/fstab && ! mount --fake | grep -q 'boot'; then
+    debug 'ERROR' 'Boot partition became unmounted during backup'
+    echo -e "${Red}!! BOOT PARTITION BECAME UNMOUNTED DURING BACKUP!!"
+    echo -e "${Red}!! RE-RUN SHRINK-BACKUP WITH -U OPTION!!"
+  fi
 return 0
 }
 

--- a/shrink-backup
+++ b/shrink-backup
@@ -56,6 +56,7 @@ function cleanup() {
     echo -e "${White}## ${IWhite}Exiting and cleaning up..."
     echo -e "${White}## ${IWhite}Please stand by..."
 
+    # Unmount img boot
     if [ -n "$BOOT_PATH" ] && [ -n "$TMP_DIR" ] && grep -qs "${TMP_DIR}${BOOT_PATH} " /proc/mounts; then
       # Loop until the mount point is not busy
       while true; do
@@ -73,6 +74,7 @@ function cleanup() {
       done
     fi
 
+    # Unmount img home (only relevant for btrfs)
     if [ -n "$TMP_DIR" ] && grep -qs "${TMP_DIR}/home " /proc/mounts; then
       while true; do
         if ! umount "${TMP_DIR}/home" && [ -n "$TMP_DIR" ] && grep -qs "${TMP_DIR}/home " /proc/mounts; then
@@ -86,6 +88,7 @@ function cleanup() {
       done
     fi
 
+    # Unmount img root
     if [ -n "$TMP_DIR" ] && grep -qs "$TMP_DIR " /proc/mounts; then
       while true; do
         if ! umount "${TMP_DIR}" && [ -n "$TMP_DIR" ] && grep -qs "$TMP_DIR " /proc/mounts; then
@@ -99,6 +102,7 @@ function cleanup() {
       done
     fi
 
+    # Remove loop
     if losetup "$LOOP" &>/dev/null; then
       while true; do
         if ! losetup -d "$LOOP"; then
@@ -112,11 +116,13 @@ function cleanup() {
       done
     fi
 
+    # Remove temp directly
     if [ -d "$TMP_DIR" ]; then
       debug 'DEBUG' "Removing temp directory in cleanup function: rm -rf $TMP_DIR"
       rm -rf "$TMP_DIR"
     fi
 
+    # Remove temp file
     if [ -f "$tmp_file" ]; then
       debug 'DEBUG' "Removing temp file in cleanup function: rm $tmp_file"
       rm "$tmp_file"
@@ -415,43 +421,45 @@ function chrootrun() {
   # ext4 or f2fs
   if [ "$FSTYPE" == 'ext4' ] || [ "$FSTYPE" == 'f2fs' ]; then
     # Assumes root is on last partition
-    count=$(( ${#LSBLK_PARTITIONS[@]} - 1 )) # ${#LSBLK_PARTITIONS[@]} gives count
-    echo -e "${White}## ${IWhite}Mounting ${Green}root (/) ${IWhite}partition"
+    count=$(( ${#LSBLK_PARTITIONS[@]} - 1 )) # ${#LSBLK_PARTITIONS[@]} gives count, -1 removes device so only partitions are counted
+    echo -e "${White}## ${IWhite}Mounting img ${Green}root (/) ${IWhite}partition"
     $SLEEPING
-    debug 'INFO' 'Mounting root partition'
+    debug 'INFO' 'Mounting img root partition'
     debug 'DEBUG' "Running: mount ${LSBLK_PARTITIONS[$count]} $TMP_DIR"
     if ! output=$(mount "${LSBLK_PARTITIONS[$count]}" "$TMP_DIR" 2>&1); then
-      echo -e "${Yellow}$output\n${Red}!! ROOT MOUNT FAILED!!!"
+      echo -e "${Yellow}$output\n${Red}!! IMG ROOT MOUNT FAILED!!!"
       debug 'BREAK'
-      debug 'ERROR' "ROOT MOUNT FAILED:\n$output\n-------------------------------------------------------------------------------------"
+      debug 'ERROR' "IMG ROOT MOUNT FAILED:\n$output\n-------------------------------------------------------------------------------------"
       exit 3
     fi
+
     # Remount with flags from fstab
     fstab=($(cat "$TMP_DIR"/etc/fstab | grep ' / '))
-    echo -e "${White}## ${IWhite}Remounting ${Green}root (/) ${IWhite}partition with flags from fstab"
+    echo -e "${White}## ${IWhite}Remounting img ${Green}root (/) ${IWhite}partition with flags from fstab"
     $SLEEPING
-    debug 'INFO' 'Remounting root partition with flags from fstab'
+    debug 'INFO' 'Remounting img root partition with flags from fstab'
     debug 'DEBUG' "Running: mount -o remount,${fstab[3]} $TMP_DIR"
     if ! output=$(mount -o remount,${fstab[3]} "$TMP_DIR" 2>&1); then
-      echo -e "${Yellow}$output\n${Red}!! REMOUNTING ROOT PARTITION FAILED!!!"
+      echo -e "${Yellow}$output\n${Red}!! REMOUNTING IMG ROOT PARTITION FAILED!!!"
       debug 'BREAK'
-      debug 'ERROR' "REMOUNTING ROOT PARTITION FAILED:\n$output\n-------------------------------------------------------------------------------------"
+      debug 'ERROR' "REMOUNTING IMG ROOT PARTITION FAILED:\n$output\n-------------------------------------------------------------------------------------"
       exit 3
     fi
+
     # Mount boot if exists
     if grep -q 'boot' $TMP_DIR/etc/fstab; then
       (( count -- ))
-      debug 'INFO' 'Boot partition found in fstab, mounting boot partition'
+      debug 'INFO' 'Boot partition found in fstab, mounting img boot partition'
       fstab=($(cat "$TMP_DIR"/etc/fstab | grep 'boot'))
 #       BOOT_PATH="${fstab[1]}" # Used to find mount in cleanup function
 #       debug 'DEBUG' "BOOT_PATH=$BOOT_PATH"
-      echo -e "${White}## ${IWhite}Mounting ${Green}${fstab[1]} ${IWhite}from fstab"
+      echo -e "${White}## ${IWhite}Mounting img ${Green}${fstab[1]} ${IWhite}from fstab"
       $SLEEPING
       debug 'DEBUG' "Running: mount -o ${fstab[3]} ${LSBLK_PARTITIONS[$count]} ${TMP_DIR}${fstab[1]}"
       if ! output=$(mount -o "${fstab[3]}" "${LSBLK_PARTITIONS[$count]}" "${TMP_DIR}${fstab[1]}" 2>&1); then
-        echo -e "${Yellow}$output\n${Red}!! BOOT MOUNT FAILED!!!"
+        echo -e "${Yellow}$output\n${Red}!! IMG BOOT MOUNT FAILED!!!"
         debug 'BREAK'
-        debug 'ERROR' "BOOT MOUNT FAILED:\n$output\n-------------------------------------------------------------------------------------"
+        debug 'ERROR' "IMG BOOT MOUNT FAILED:\n$output\n-------------------------------------------------------------------------------------"
         exit 3
       fi
     fi
@@ -459,45 +467,45 @@ function chrootrun() {
   # btrfs
   elif [ "$FSTYPE" == 'btrfs' ]; then
     # Assumes root subvolume is @ and is on second partition
-    echo -e "${White}## ${IWhite}Mounting ${Green}@ ${IWhite}subvolume"
+    echo -e "${White}## ${IWhite}Mounting img ${Green}@ ${IWhite}subvolume"
     $SLEEPING
-    debug 'INFO' 'Mounting @ subvolume'
+    debug 'INFO' 'Mounting img @ subvolume'
     debug 'DEBUG' "Running: mount -o subvol=@ ${LSBLK_PARTITIONS[2]} $TMP_DIR"
     if ! output=$(mount -o subvol=@ "${LSBLK_PARTITIONS[2]}" "$TMP_DIR" 2>&1); then
-      echo -e "${Yellow}$output\n${Red}!! ROOT SUBVOLUME (@) MOUNT FAILED!!!"
+      echo -e "${Yellow}$output\n${Red}!! IMG ROOT SUBVOLUME (@) MOUNT FAILED!!!"
       debug 'BREAK'
-      debug 'ERROR' "ROOT SUBVOLUME (@) MOUNT FAILED:\n$output\n-------------------------------------------------------------------------------------"
+      debug 'ERROR' "IMG ROOT SUBVOLUME (@) MOUNT FAILED:\n$output\n-------------------------------------------------------------------------------------"
       exit 3
     fi
     # Remount with flags from fstab
     fstab=($(cat "$TMP_DIR"/etc/fstab | grep ' / '))
-    echo -e "${White}## ${IWhite}Remounting ${Green}@ ${IWhite}subvolume with flags from fstab"
+    echo -e "${White}## ${IWhite}Remounting img ${Green}@ ${IWhite}subvolume with flags from fstab"
     $SLEEPING
-    debug 'INFO' 'Remounting @ with flags from fstab'
+    debug 'INFO' 'Remounting img @ subvolume with flags from fstab'
     debug 'DEBUG' "Running: mount -o remount,${fstab[3]} $TMP_DIR"
     if ! output=$(mount -o remount,${fstab[3]} "$TMP_DIR" 2>&1); then
-      echo -e "${Yellow}$output\n${Red}!! REMOUNTING ROOT SUBVOLUME (@) FAILED!!!"
+      echo -e "${Yellow}$output\n${Red}!! REMOUNTING IMG ROOT SUBVOLUME (@) FAILED!!!"
       debug 'BREAK'
-      debug 'ERROR' "REMOUNTING ROOT SUBVOLUME (@) FAILED:\n$output\n-------------------------------------------------------------------------------------"
+      debug 'ERROR' "REMOUNTING IMG ROOT SUBVOLUME (@) FAILED:\n$output\n-------------------------------------------------------------------------------------"
       exit 3
     fi
     # Assumes boot exists and is on first partition
     fstab=($(cat "$TMP_DIR"/etc/fstab | grep 'boot'))
 #     BOOT_PATH="${fstab[1]}" # Used to find mount in cleanup function
 #     debug 'DEBUG' "BOOT_PATH=$BOOT_PATH"
-    debug 'INFO' 'Mounting boot partition'
-    echo -e "${White}## ${IWhite}Mounting ${Green}${fstab[1]} ${IWhite}from fstab"
+    debug 'INFO' 'Mounting img boot partition'
+    echo -e "${White}## ${IWhite}Mounting img ${Green}${fstab[1]} ${IWhite}from fstab"
     $SLEEPING
     debug 'DEBUG' "Running: mount -o ${fstab[3]} ${LSBLK_PARTITIONS[1]} ${TMP_DIR}${fstab[1]}"
     if ! output=$(mount -o "${fstab[3]}" "${LSBLK_PARTITIONS[1]}" "${TMP_DIR}${fstab[1]}" 2>&1); then
-      echo -e "${Yellow}$output\n${Red}!! BOOT MOUNT FAILED!!!"
+      echo -e "${Yellow}$output\n${Red}!! IMG BOOT MOUNT FAILED!!!"
       debug 'BREAK'
-      debug 'ERROR' "BOOT MOUNT FAILED:\n$output\n-------------------------------------------------------------------------------------"
+      debug 'ERROR' "IMG BOOT MOUNT FAILED:\n$output\n-------------------------------------------------------------------------------------"
       exit 3
     fi
     # Filter out @ and subvolumes not in fstab
     IMG_SUBVOLUMES=($(btrfs subvol list $TMP_DIR | awk '{print $9}'))
-    echo -e "${White}## ${IWhite}Subvolumes found on image ${Green}${IMG_SUBVOLUMES[@]}"
+    echo -e "${White}## ${IWhite}Subvolumes found on img ${Green}${IMG_SUBVOLUMES[@]}"
     echo -e "${White}## ${IWhite}Filtering out subvolumes not present in fstab"
     $SLEEPING
     debug 'INFO' 'Filtering out @ and subvolumes not in fstab'
@@ -514,13 +522,13 @@ function chrootrun() {
     debug 'INFO' 'Mounting remaining subvolumes'
     for subvol in ${IMG_SUBVOLUMES[@]}; do
       fstab=($(cat "$TMP_DIR"/etc/fstab | grep "$subvol"))
-      echo -e "${White}## ${IWhite}Mounting ${Green}${fstab[1]} ${IWhite}from fstab"
+      echo -e "${White}## ${IWhite}Mounting img ${Green}${fstab[1]} ${IWhite}from fstab"
       $SLEEPING
       debug 'DEBUG' "Running: mount -o ${fstab[3]} ${LSBLK_PARTITIONS[2]} ${TMP_DIR}${fstab[1]}"
       if ! output=$(mount -o "${fstab[3]}" "${LSBLK_PARTITIONS[2]}" "${TMP_DIR}${fstab[1]}" 2>&1); then
         echo -e "${Yellow}$output\n${Red}!! SUBVOLUME MOUNT FAILED!!!"
         debug 'BREAK'
-        debug 'ERROR' "SUBVOLUME MOUNT FAILED:\n$output\n-------------------------------------------------------------------------------------"
+        debug 'ERROR' "IMG SUBVOLUME MOUNT FAILED:\n$output\n-------------------------------------------------------------------------------------"
         exit 3
       fi
     done
@@ -529,11 +537,11 @@ function chrootrun() {
   # Enter chroot environment
   echo -e "${White}## ${IWhite}Running systemd-nspawn, type ${Green}exit ${IWhite}when done to exit chroot environment"
   echo -e "${White}## ${Yellow}YOU ARE RUNNING AS ROOT!!!${NC}"
-  if systemctl is-active -q systemctl-resolved.service; then
-    debug 'DEBUG' "Running: systemd-nspawn --resolv-conf=replace-stub -D $TMP_DIR bin/bash"
+  if systemctl is-active -q systemd-resolved.service; then
+    debug 'DEBUG' "systemd-resolved.service is active, running: systemd-nspawn --resolv-conf=replace-stub -D $TMP_DIR bin/bash"
     systemd-nspawn --resolv-conf=replace-stub -D "$TMP_DIR" bin/bash
   else
-    debug 'DEBUG' "Running: systemd-nspawn --resolv-conf=copy-host -D $TMP_DIR bin/bash"
+    debug 'DEBUG' "systemd-resolved.service is not active, running: systemd-nspawn --resolv-conf=copy-host -D $TMP_DIR bin/bash"
     systemd-nspawn --resolv-conf=copy-host -D "$TMP_DIR" bin/bash
   fi
 exit 0
@@ -863,14 +871,14 @@ function check_dependencies() {
           pacman -Syu --noconfirm && pacman -S --noconfirm gptfdisk
         fi
 
-      # Neither apt nor pacman available
+      # Installation failed or neither apt nor pacman is available
       else
-        echo -e "${Red}!! Error! ${Yellow}Installing gdisk failed! ${Green}Please install gdisk manually and retry script..."
-        debug 'ERROR' 'Installing gdisk failed, aborting exit 3'
+        echo -e "${Red}!! Error! ${Yellow}Installing sgdisk failed! ${Green}Please install sgdisk manually and retry script..."
+        debug 'ERROR' 'Installing sgdisk failed, aborting exit 3'
         echo -e "${Red}!! Aborting..."
         exit 3
       fi
-      echo -e "${White}## ${Green}gdisk installed successfully, ${IWhite}resuming backup..."
+      echo -e "${White}## ${Green}sgdisk installed successfully, ${IWhite}resuming backup..."
       debug 'INFO' 'gdisk installed successfully'
       $SLEEPING
 
@@ -882,7 +890,7 @@ function check_dependencies() {
     fi
   fi
 
-  # f2fs conversion
+  # f2fs conversion (only apt)
   if [ "$F2FS_CONVERSION" = true ]; then
     echo -e "${White}## ${Green}--f2fs option selected, mkfs.f2fs is needed, ${IWhite}checking for application..."
     $SLEEPING
@@ -917,9 +925,9 @@ function check_dependencies() {
           apt update -y && apt upgrade -y && apt install f2fs-tools -y
         fi
 
-      # apt not available
+      # Installation failed
       else
-        echo -e "${Red}!! Error! ${Yellow}Installing gdisk failed! ${Green}Please install mkfs.f2fs manually and retry script..."
+        echo -e "${Red}!! Error! ${Yellow}Installing mkfs.f2fs (f2fs-tools) failed! ${Green}Please install f2fs-tools manually and retry script..."
         debug 'ERROR' 'Installing f2fs-tools failed, aborting exit 3'
         echo -e "${Red}!! Aborting..."
         exit 3
@@ -933,12 +941,12 @@ function check_dependencies() {
     fi
   fi
 
-  # btrfs conversion
+  # btrfs conversion (work in progress)
   if [ "$BTRFS_CONVERSION" = true ]; then
     echo 'btrfs'
   fi
 
-  # --chroot selected
+  # --chroot selected (only apt)
   if [ "$CHROOTRUN" = true ]; then
     echo -e "${White}## ${Green}--chrootrun ${IWhite}selected, ${Yellow}systemd-nspawn needed, ${IWhite}checking for application..."
     $SLEEPING
@@ -975,6 +983,13 @@ function check_dependencies() {
         echo -e "${White}## ${Green}systemd-container installed successfully, ${IWhite}resuming..."
         debug 'INFO' 'systemd-container installed successfully'
         $SLEEPING
+
+      # Installation failed
+      else
+        echo -e "${Red}!! Error! ${Yellow}Installing systemd-nspawn (systemd-container) failed! ${Green}Please install systemd-container manually and retry script..."
+        debug 'ERROR' 'Installing systemd-container failed, aborting exit 3'
+        echo -e "${Red}!! Aborting..."
+        exit 3
       fi
 
     # systemd-nspawn already installed

--- a/shrink-backup
+++ b/shrink-backup
@@ -2247,6 +2247,20 @@ return 0
 
 
 
+# Enable autoexpansion for Kali-ARM
+function autoexpansion_kali() {
+  if ! test -L "${TMP_DIR}/etc/systemd/system/basic.target.wants/rpi-resizerootfs.service"; then
+    debug 'DEBUG' "Enabling systemd service by creating symlink: ln -s /etc/systemd/system/rpi-resizerootfs.service ${TMP_DIR}/etc/systemd/system/basic.target.wants/rpi-resizerootfs.service"
+    ln -s /etc/systemd/system/rpi-resizerootfs.service ${TMP_DIR}/etc/systemd/system/basic.target.wants/rpi-resizerootfs.service
+  fi
+  echo -e "${White}## ${Green}Kali-ARM filesystem autoresizing at boot..."
+  debug 'INFO' 'Kali-ARM filesystem autoresizing at boot'
+  $SLEEPING
+return 0
+}
+
+
+
 # Print result
 function print_result() {
 
@@ -2292,13 +2306,13 @@ function print_result() {
     echo -e "# ${IWhite}Image size: ${Green}${AFTER_SIZE}MiB ${IWhite}with a ${Green}root partition ${IWhite}of ${Green}${print_temp}MiB ${Purple}$(printf "%+$(( COLS - 45 - $(echo ${AFTER_SIZE} | wc -m ) - $(echo ${print_temp} | wc -m ) ))s" '#')"
     debug 'INFO' "$IMG_FILE is ${AFTER_SIZE}MiB"
   fi
-  if [ "$AUTOEXPAND" = true ]; then
+  if [ "$AUTOEXPAND" = true ] && [ "$OS" != 'armbian' ] && [ "$OS" != 'kali' ]; then
     echo -e "# ${Yellow}Please wait for the system to reboot after restoring an image with autoexpansion ${Purple}$(printf "%+$(( COLS - 83 ))s" '#')"
   fi
   echo -e "${Purple}${BREAK}"
   debug 'INFO' 'Backup done'
   debug 'BREAK'
-  
+
   # Make sure boot partition was not unmounted during backup
   if grep -q 'boot' /etc/fstab && ! mount --fake | grep -q 'boot'; then
     debug 'ERROR' 'Boot partition became unmounted during backup'
@@ -2520,6 +2534,11 @@ elif grep -qsi 'archlinuxarm' /etc/os-release; then
   OS='archlinux-arm'
   debug 'INFO' 'ArchLinux-arm detected'
   $SLEEPING
+elif grep -qsi 'kali' /etc/os-release; then
+  echo -e "${White}## ${Green}Kali-ARM detected"
+  OS='kali'
+  debug 'INFO' 'Kali-ARM detected'
+  $SLEEPING
 else
   echo -e "${Yellow}!! Unknown OS"
   OS='unknown'
@@ -2584,6 +2603,7 @@ if [ "$AUTOEXPAND" = true ]; then
     armbian) echo -e "${White}## ${IWhite}Enabling autoexpansion for ${Green}Armbian..."; debug 'INFO' 'Running function: autoexpansion_armbian'; autoexpansion_armbian;;
     manjaro-arm) echo -e "${White}## ${IWhite}Enabling autoexpansion for ${Green}Manjaro-arm..."; debug 'INFO' 'Running function: autoexpansion_manjaro'; autoexpansion_manjaro;;
     archlinux-arm) echo -e "${White}## ${IWhite}Enabling autoexpansion for ${Green}ArchLinux-arm..."; debug 'INFO' 'Running function: autoexpansion_arch'; autoexpansion_arch;;
+    kali) echo -e "${White}## ${IWhite}Enabling autoexpansion for ${Green}Kali-ARM..."; debug 'INFO' 'Running function: autoexpansion_kali'; autoexpansion_kali;;
     unknown) echo -e "${Yellow}!! No autoexpand option available for this OS!"; debug 'WARNING' 'No autoexpand option available for this OS'; AUTOEXPAND='failed';;
   esac
 fi


### PR DESCRIPTION
- New options:
	- `-q|--quiet` mode. Mute rsync output
	- `--no-color` mode. No colorization in script
	- `--rsync`. User will get presented with the rsync line that will be ran and can modify it
- Autoexpansion for operating systems:
	- Kali-arm
	- Ubuntu-server-arm (Ubuntu autoexpands by default, but that can be disabled with `-e` option)
- UI tweaks
- Removed check for .img extension while using `--loop` so it works on other img formats (for example .iso)
- Changed the `dd` line to use `conv=fsync` instead of `sync` and added a `sync` operation after `dd` is done to try to mitigate the "can not set loop paths" problem that some users experience
- `--chroot` option to access an image in a chroot environment (`systemd-nspawn`) to for example update/install packages or rebuild initramfs. Only works from the system you created the img
- User confirmation now require to also press enter after y/n
- Added `/snap/*` in `exclude.txt` and to be excluded as default if not using the exclude file
- Implemented a lock file that makes it impossible for boot partition to become unmounted during shrink-backup
- Nested `btrfs` subvolumes can now be added & removed in an update (`-U`)
- New way of excluding subvolumes for `btrfs` (`exclude_btrfs.txt` or `shrink-backup_btrfs.conf` depending on how you installed, see [README](https://github.com/UnconnectedBedna/shrink-backup/discussions) for information)
- `--fix` now also adds option `--fsync` to `rsync`

If you have made changes to `exclude.txt` and you used `git` to install, `git pull` will fail due to conflicts.
The easiest way to resolve this is to make notes of the paths you added, then:
```
git reset --hard
git pull
```
Then add your edited paths back into `exclude.txt` at the end of the file again.