### PR TITLE
Fix broken autoexpansion condition

### DIFF
--- a/shrink-backup
+++ b/shrink-backup
@@ -1310,7 +1310,7 @@ function do_e2fsck() {
     $SLEEPING
 
     # Remounting if autoexpansion is requested
-    if [ "$AUTOEXPAND" = true ] && [ "$OS" != 'unknown' ] || [ "$AUTOEXPAND" = false ] && [ "$OS" == 'ubuntu' ]; then
+    if [[ ( "$AUTOEXPAND" == true  && "$OS" != unknown ) || ( "$AUTOEXPAND" == false && "$OS" == ubuntu ) ]]; then
       echo -e "${White}## ${IWhite}Remounting for autoexpansion..."
       debug 'INFO' 'Remounting for autoexpansion function'
       debug 'INFO' 'Running function: do_mount'


### PR DESCRIPTION
shrink-backup was producing a broken image for me. There were no errors in `shrink-backup.log`, but the stdout output did show the following:

`ln: failed to create symbolic link '/tmp/backup-ejy/etc/systemd/system/basic.target.wants/armbian-resize-filesystem.service': No such file or directory`

Here's a relevant section of the log file produced:

```
-------------------------------------------------------------------------------------
2025-08-28 09:23:24 [INFO]    - Rsync done
2025-08-28 09:23:28 [INFO]    - Running function: do_e2fsck 'final'
2025-08-28 09:23:28 [INFO]    - Unmounting root partition
2025-08-28 09:23:28 [DEBUG]   - Running: umount /tmp/backup-E6Q
-------------------------------------------------------------------------------------
2025-08-28 09:24:04 [DEBUG]   - Running: e2fsck -p -f -v /dev/loop0p1
armbi_root: /lost+found not found.  CREATED.

      596941 inodes used (39.33%, out of 1517760)
         226 non-contiguous files (0.0%)
         299 non-contiguous directories (0.1%)
             # of inodes with ind/dind/tind blocks: 0/0/0
             Extent depth histogram: 575555/16
     5191012 blocks used (85.56%, out of 6067443)
           0 bad blocks
           1 large file

      506722 regular files
       66759 directories
          72 character device files
           1 block device file
          75 fifos
        3128 links
       23285 symbolic links (21197 fast symbolic links)
          16 sockets
------------
      600058 files
-------------------------------------------------------------------------------------
2025-08-28 09:24:05 [INFO]    - Running autoexpand function
2025-08-28 09:24:06 [INFO]    - Running function: autoexpansion_armbian
2025-08-28 09:24:06 [DEBUG]   - Enabling systemd service by creating symlink: ln -s /lib/systemd/system/armbian-resize-filesystem.service /tmp/backup-E6Q/etc/systemd/system/basic.target.wants/armbian-resize-filesystem.service
2025-08-28 09:24:06 [INFO]    - Armbian filesystem autoresizing at boot
2025-08-28 09:24:07 [INFO]    - Img file created
```

As you can see, it's supposed to be autoexpanding but my log file had no mention of [these two lines](https://github.com/UnconnectedBedna/shrink-backup/blob/testing/shrink-backup#L1315-L1316), hinting that the issue was in the condition above because we were not remounting the image to set autoexpansion.

In POSIX shells (and Bash), && and || have the same precedence and are left-associative. This means that this expression:

```bash
[ "$AUTOEXPAND" = true ] && [ "$OS" != 'unknown' ] || [ "$AUTOEXPAND" = false ] && [ "$OS" == 'ubuntu' ]
```

is actually parsed as

```bash
(([ "$AUTOEXPAND" = true ] && [ "$OS" != 'unknown' ]) || [ "$AUTOEXPAND" = false ]) && [ "$OS" == 'ubuntu' ]
```

or more simply: `(((A && B) || C) && D)`

where
```
A = [ "$AUTOEXPAND" = true ] -> true
B = [ "$OS" != 'unknown' ] -> true
C = [ "$AUTOEXPAND" = false ] -> false
D = [ "$OS" == 'ubuntu' ] -> false (since OS=armbian)
```

Result: `((true && true) || false) && false -> true && false -> false`.

This PR fixes the issue for me and I finally have a working backup image for my sbc! 🎉 